### PR TITLE
WIP: Implement Update dialog multi-field layout (WL-0ML1R8E4L0BVNT39)

### DIFF
--- a/src/commands/tui.ts
+++ b/src/commands/tui.ts
@@ -1135,7 +1135,7 @@ export default function register(ctx: PluginContext): void {
         if (item) {
           updateDialogText.setContent(`Update: ${item.title}\nID: ${item.id}`);
         } else {
-          updateDialogText.setContent('Update selected item stage:');
+          updateDialogText.setContent('Update selected item fields:');
         }
         updateOverlay.show();
         updateDialog.show();

--- a/src/tui/components/dialogs.ts
+++ b/src/tui/components/dialogs.ts
@@ -103,8 +103,8 @@ export class DialogsComponent {
       parent: this.screen,
       top: 'center',
       left: 'center',
-      width: '50%',
-      height: 14,
+      width: '70%',
+      height: 24,
       label: ' Update Work Item ',
       border: { type: 'line' },
       hidden: true,
@@ -120,16 +120,50 @@ export class DialogsComponent {
       left: 2,
       height: 2,
       width: '100%-4',
-      content: 'Update selected item stage:',
+      content: 'Update selected item fields:',
       tags: false,
     });
 
-    this.updateDialogOptions = this.blessedImpl.list({
+    const updateDialogColumnWidth = '33%-2';
+    const updateDialogListHeight = 15;
+    const updateDialogListTop = 6;
+
+    this.blessedImpl.box({
       parent: this.updateDialog,
       top: 4,
       left: 2,
-      width: '100%-4',
-      height: 8,
+      height: 1,
+      width: updateDialogColumnWidth,
+      content: 'Stage',
+      tags: false,
+    });
+
+    this.blessedImpl.box({
+      parent: this.updateDialog,
+      top: 4,
+      left: '33%+1',
+      height: 1,
+      width: updateDialogColumnWidth,
+      content: 'Status',
+      tags: false,
+    });
+
+    this.blessedImpl.box({
+      parent: this.updateDialog,
+      top: 4,
+      left: '66%+1',
+      height: 1,
+      width: updateDialogColumnWidth,
+      content: 'Priority',
+      tags: false,
+    });
+
+    const stageList = this.blessedImpl.list({
+      parent: this.updateDialog,
+      top: updateDialogListTop,
+      left: 2,
+      width: updateDialogColumnWidth,
+      height: updateDialogListHeight,
       keys: true,
       mouse: true,
       style: {
@@ -137,6 +171,60 @@ export class DialogsComponent {
       },
       items: ['idea', 'prd_complete', 'plan_complete', 'in_progress', 'in_review', 'done', 'blocked', 'Cancel'],
     });
+
+    const statusList = this.blessedImpl.list({
+      parent: this.updateDialog,
+      top: updateDialogListTop,
+      left: '33%+1',
+      width: updateDialogColumnWidth,
+      height: updateDialogListHeight,
+      keys: true,
+      mouse: true,
+      style: {
+        selected: { bg: 'blue' },
+      },
+      items: ['open', 'in-progress', 'blocked', 'completed', 'deleted', 'Cancel'],
+    });
+
+    const priorityList = this.blessedImpl.list({
+      parent: this.updateDialog,
+      top: updateDialogListTop,
+      left: '66%+1',
+      width: updateDialogColumnWidth,
+      height: updateDialogListHeight,
+      keys: true,
+      mouse: true,
+      style: {
+        selected: { bg: 'blue' },
+      },
+      items: ['critical', 'high', 'medium', 'low', 'Cancel'],
+    });
+
+    this.updateDialogOptions = stageList;
+
+    const updateLayout = () => {
+      const screenHeight = Math.max(0, this.screen.height as number);
+      const screenWidth = Math.max(0, this.screen.width as number);
+      if (!screenHeight || !screenWidth) return;
+
+      if (screenHeight < 28) {
+        const height = Math.max(16, screenHeight - 4);
+        this.updateDialog.height = height;
+        stageList.height = Math.max(6, height - 9);
+        statusList.height = stageList.height;
+        priorityList.height = stageList.height;
+      } else {
+        this.updateDialog.height = 24;
+        stageList.height = updateDialogListHeight;
+        statusList.height = updateDialogListHeight;
+        priorityList.height = updateDialogListHeight;
+      }
+
+      this.updateDialog.width = screenWidth < 100 ? '90%' : '70%';
+    };
+
+    this.updateDialog.on('show', updateLayout);
+    this.screen.on('resize', updateLayout);
   }
 
   create(): this {

--- a/tests/tui/tui-update-dialog.test.ts
+++ b/tests/tui/tui-update-dialog.test.ts
@@ -112,7 +112,7 @@ describe('TUI Update Dialog', () => {
   });
 
   describe('Update Dialog UI Behavior', () => {
-    it('should render update dialog with stage options', () => {
+    it('should render update dialog with stage, status, and priority options', () => {
       // Create blessed screen and dialog components
       const screen = blessed.screen({ mouse: true, smartCSR: true });
 
@@ -120,8 +120,8 @@ describe('TUI Update Dialog', () => {
         parent: screen,
         top: 'center',
         left: 'center',
-        width: '50%',
-        height: 14,
+        width: '70%',
+        height: 24,
         label: ' Update Work Item ',
         border: { type: 'line' },
         hidden: true,
@@ -137,16 +137,46 @@ describe('TUI Update Dialog', () => {
         left: 2,
         height: 2,
         width: '100%-4',
-        content: 'Update selected item stage:',
+        content: 'Update selected item fields:',
         tags: false
       });
 
-      const updateDialogOptions = blessed.list({
+      blessed.box({
         parent: updateDialog,
         top: 4,
         left: 2,
-        width: '100%-4',
-        height: 8,
+        height: 1,
+        width: '33%-2',
+        content: 'Stage',
+        tags: false
+      });
+
+      blessed.box({
+        parent: updateDialog,
+        top: 4,
+        left: '33%+1',
+        height: 1,
+        width: '33%-2',
+        content: 'Status',
+        tags: false
+      });
+
+      blessed.box({
+        parent: updateDialog,
+        top: 4,
+        left: '66%+1',
+        height: 1,
+        width: '33%-2',
+        content: 'Priority',
+        tags: false
+      });
+
+      const stageOptions = blessed.list({
+        parent: updateDialog,
+        top: 6,
+        left: 2,
+        width: '33%-2',
+        height: 15,
         keys: true,
         mouse: true,
         style: {
@@ -164,10 +194,42 @@ describe('TUI Update Dialog', () => {
         ]
       });
 
+      const statusOptions = blessed.list({
+        parent: updateDialog,
+        top: 6,
+        left: '33%+1',
+        width: '33%-2',
+        height: 15,
+        keys: true,
+        mouse: true,
+        style: {
+          selected: { bg: 'blue' }
+        },
+        items: ['open', 'in-progress', 'blocked', 'completed', 'deleted', 'Cancel']
+      });
+
+      const priorityOptions = blessed.list({
+        parent: updateDialog,
+        top: 6,
+        left: '66%+1',
+        width: '33%-2',
+        height: 15,
+        keys: true,
+        mouse: true,
+        style: {
+          selected: { bg: 'blue' }
+        },
+        items: ['critical', 'high', 'medium', 'low', 'Cancel']
+      });
+
       // Verify dialog is properly constructed
       expect(updateDialog.hidden).toBe(true);
-      // Verify the list has items (blessed list items API)
-      expect(updateDialogOptions.children.length).toBeGreaterThan(0);
+      expect(updateDialogText.getContent()).toContain('Update selected item fields:');
+
+      // Verify lists have items (blessed list items API)
+      expect(stageOptions.children.length).toBeGreaterThan(0);
+      expect(statusOptions.children.length).toBeGreaterThan(0);
+      expect(priorityOptions.children.length).toBeGreaterThan(0);
 
       screen.destroy();
     });
@@ -179,8 +241,8 @@ describe('TUI Update Dialog', () => {
         parent: screen,
         top: 'center',
         left: 'center',
-        width: '50%',
-        height: 14,
+        width: '70%',
+        height: 24,
         label: ' Update Work Item ',
         border: { type: 'line' },
         hidden: true
@@ -222,8 +284,8 @@ describe('TUI Update Dialog', () => {
         parent: screen,
         top: 'center',
         left: 'center',
-        width: '50%',
-        height: 14,
+        width: '70%',
+        height: 24,
         label: ' Update Work Item ',
         border: { type: 'line' },
         hidden: true


### PR DESCRIPTION
## Summary
- Expand Update dialog to a 3-column layout for stage/status/priority
- Add resize-aware sizing for smaller terminals
- Update Update-dialog UI tests for the new layout and copy

## Testing
- npm test

## Worklog
- WL-0ML1R8E4L0BVNT39