### PR TITLE
WIP: Dependency Edge DB Model (WL-0ML505YUB1LZKTY3)

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -132,6 +132,16 @@ export interface Comment {
 }
 
 /**
+ * Represents a dependency edge between work items
+ * fromId depends on toId
+ */
+export interface DependencyEdge {
+  fromId: string;
+  toId: string;
+  createdAt: string;
+}
+
+/**
  * Input for creating a new comment
  */
 export interface CreateCommentInput {

--- a/tests/database.test.ts
+++ b/tests/database.test.ts
@@ -336,6 +336,52 @@ describe('WorklogDatabase', () => {
     });
   });
 
+  describe('dependency edges', () => {
+    it('should add and list outbound dependency edges', () => {
+      const from = db.create({ title: 'From' });
+      const to = db.create({ title: 'To' });
+
+      const edge = db.addDependencyEdge(from.id, to.id);
+      expect(edge).toBeDefined();
+      expect(edge?.fromId).toBe(from.id);
+      expect(edge?.toId).toBe(to.id);
+
+      const outbound = db.listDependencyEdgesFrom(from.id);
+      expect(outbound).toHaveLength(1);
+      expect(outbound[0].fromId).toBe(from.id);
+      expect(outbound[0].toId).toBe(to.id);
+    });
+
+    it('should list inbound dependency edges', () => {
+      const from = db.create({ title: 'From' });
+      const to = db.create({ title: 'To' });
+
+      db.addDependencyEdge(from.id, to.id);
+
+      const inbound = db.listDependencyEdgesTo(to.id);
+      expect(inbound).toHaveLength(1);
+      expect(inbound[0].fromId).toBe(from.id);
+      expect(inbound[0].toId).toBe(to.id);
+    });
+
+    it('should remove dependency edges', () => {
+      const from = db.create({ title: 'From' });
+      const to = db.create({ title: 'To' });
+      db.addDependencyEdge(from.id, to.id);
+
+      const removed = db.removeDependencyEdge(from.id, to.id);
+      expect(removed).toBe(true);
+      expect(db.listDependencyEdgesFrom(from.id)).toHaveLength(0);
+      expect(db.listDependencyEdgesTo(to.id)).toHaveLength(0);
+    });
+
+    it('should return null when adding edge with missing items', () => {
+      const from = db.create({ title: 'From' });
+      const edge = db.addDependencyEdge(from.id, 'TEST-NOTFOUND');
+      expect(edge).toBeNull();
+    });
+  });
+
   describe('import and export', () => {
     it('should import work items', () => {
       const items = [


### PR DESCRIPTION
## Summary
- Add dependency edge table and accessors to the persistent store.
- Add WorklogDatabase APIs for add/remove/list inbound/outbound edges.
- Add unit tests for dependency edge persistence.

## Testing
- `npm test`

## Reviewer Notes
- Schema migration in `src/persistent-store.ts` bumps schema version to 6 and creates `dependency_edges`.
- The DB import clears dependency edges to avoid stale data.