### PR TITLE
WIP: JSONL Work Item Embedding (WL-0ML506AWS048DMBA)

### DIFF
--- a/src/api.ts
+++ b/src/api.ts
@@ -371,7 +371,8 @@ export function createAPI(db: WorklogDatabase) {
       const filepath = req.body.filepath || getDefaultDataPath();
       const items = db.getAll();
       const comments = db.getAllComments();
-      exportToJsonl(items, comments, filepath);
+      const dependencyEdges = db.getAllDependencyEdges();
+      exportToJsonl(items, comments, filepath, dependencyEdges);
       res.json({ message: 'Export successful', filepath, count: items.length, commentCount: comments.length });
     } catch (error) {
       res.status(500).json({ error: (error as Error).message });
@@ -383,8 +384,8 @@ export function createAPI(db: WorklogDatabase) {
     try {
       db.setPrefix(defaultPrefix);
       const filepath = req.body.filepath || getDefaultDataPath();
-      const { items, comments } = importFromJsonl(filepath);
-      db.import(items);
+      const { items, comments, dependencyEdges } = importFromJsonl(filepath);
+      db.import(items, dependencyEdges);
       db.importComments(comments);
       res.json({ message: 'Import successful', count: items.length, commentCount: comments.length });
     } catch (error) {

--- a/src/commands/export.ts
+++ b/src/commands/export.ts
@@ -19,7 +19,8 @@ export default function register(ctx: PluginContext): void {
       const db = utils.getDatabase(options.prefix);
       const items = db.getAll();
       const comments = db.getAllComments();
-      exportToJsonl(items, comments, options.file || dataPath);
+      const dependencyEdges = db.getAllDependencyEdges();
+      exportToJsonl(items, comments, options.file || dataPath, dependencyEdges);
       
       if (utils.isJsonMode()) {
         output.json({ 

--- a/src/commands/import.ts
+++ b/src/commands/import.ts
@@ -17,8 +17,8 @@ export default function register(ctx: PluginContext): void {
     .action((options: ImportOptions) => {
       utils.requireInitialized();
       const db = utils.getDatabase(options.prefix);
-      const { items, comments } = importFromJsonl(options.file || dataPath);
-      db.import(items);
+      const { items, comments, dependencyEdges } = importFromJsonl(options.file || dataPath);
+      db.import(items, dependencyEdges);
       db.importComments(comments);
       
       if (utils.isJsonMode()) {

--- a/src/persistent-store.ts
+++ b/src/persistent-store.ts
@@ -458,6 +458,13 @@ export class SqlitePersistentStore {
   }
 
   /**
+   * Clear all dependency edges
+   */
+  clearDependencyEdges(): void {
+    this.db.prepare('DELETE FROM dependency_edges').run();
+  }
+
+  /**
    * Import work items and comments (replaces existing data)
    */
   importData(items: WorkItem[], comments: Comment[]): void {

--- a/src/types.ts
+++ b/src/types.ts
@@ -8,6 +8,14 @@ export type WorkItemRiskLevel = 'Low' | 'Medium' | 'High' | 'Severe';
 export type WorkItemEffortLevel = 'XS' | 'S' | 'M' | 'L' | 'XL';
 
 /**
+ * JSONL dependency edge representation
+ */
+export interface WorkItemDependency {
+  from: string;
+  to: string;
+}
+
+/**
  * Represents a work item in the system
  */
 export interface WorkItem {
@@ -23,6 +31,9 @@ export interface WorkItem {
   tags: string[];
   assignee: string;
   stage: string;
+
+  // Optional dependency edges (JSONL import/export)
+  dependencies?: WorkItemDependency[];
 
   // Optional metadata for import/interoperability with other issue trackers
   issueType: string;

--- a/tests/cli/cli-helpers.ts
+++ b/tests/cli/cli-helpers.ts
@@ -125,6 +125,6 @@ export function seedWorkItems(
   }));
 
   const dataPath = path.join(dir, '.worklog', 'worklog-data.jsonl');
-  exportToJsonl(seeded, comments, dataPath);
+  exportToJsonl(seeded, comments, dataPath, []);
   return seeded;
 }


### PR DESCRIPTION
## Summary
- Embed dependency edges in JSONL export (dependencies: [{from,to}]).
- Import dependencies from JSONL and reconstruct dependency edges.
- Extend sync/init/import/export paths to carry dependency edges.

## Testing
- `npm test`

## Reviewer Notes
- JSONL import now defaults missing dependencies to empty arrays.
- Dependency edges are merged and exported alongside items/comments.