### PR TITLE
WIP: Document dependency edges (WL-0ML4TFTCJ0PGY47E)

### DIFF
--- a/CLI.md
+++ b/CLI.md
@@ -123,6 +123,10 @@ wl close WL-ABC123 WL-DEF456 -r "Cleanup after release"
 
 Manage dependency edges attached to work items. Use `wl dep <subcommand>`.
 
+Notes:
+
+- Prefer dependency edges for new work; they are the recommended way to track blockers.
+
 Subcommands:
 
 - `add <itemId> <dependsOnId>` — Create a dependency where `itemId` depends on `dependsOnId`.


### PR DESCRIPTION
## Summary
- Update CLI dependency docs to remove blocked-by guidance.
- Emphasize dependency edges as the recommended path.

## Testing
- `npm test` (fails on flaky tests/sort-operations.test.ts timeout; tracking WL-0ML5XWRC61PHFDP2)

## Reviewer Notes
- Doc-only change in CLI.md.