### PR TITLE
WL-0ML2V8MAC0W77Y1G: centralize status/stage validation

### DIFF
--- a/src/tui/status-stage-validation.ts
+++ b/src/tui/status-stage-validation.ts
@@ -1,0 +1,44 @@
+import type { WorkItemStatus } from '../types.js';
+import { STATUS_STAGE_COMPATIBILITY, STAGE_STATUS_COMPATIBILITY } from './status-stage-rules.js';
+
+export interface StatusStageValidationRules {
+  statusStage?: Record<string, readonly string[]>;
+  stageStatus?: Record<string, readonly string[]>;
+}
+
+const resolveStatusStageRules = (rules?: StatusStageValidationRules) =>
+  rules?.statusStage ?? STATUS_STAGE_COMPATIBILITY;
+
+const resolveStageStatusRules = (rules?: StatusStageValidationRules) =>
+  rules?.stageStatus ?? STAGE_STATUS_COMPATIBILITY;
+
+export const getAllowedStagesForStatus = (
+  status?: string,
+  rules?: StatusStageValidationRules
+): readonly string[] => {
+  if (!status) return [];
+  const statusStageRules = resolveStatusStageRules(rules);
+  return statusStageRules[status as WorkItemStatus] ?? [];
+};
+
+export const getAllowedStatusesForStage = (
+  stage?: string,
+  rules?: StatusStageValidationRules
+): readonly string[] => {
+  if (stage === undefined) return [];
+  const stageStatusRules = resolveStageStatusRules(rules);
+  return stageStatusRules[stage] ?? [];
+};
+
+export const isStatusStageCompatible = (
+  status?: string,
+  stage?: string,
+  rules?: StatusStageValidationRules
+): boolean => {
+  if (!status || stage === undefined) return true;
+  const allowedStages = getAllowedStagesForStatus(status, rules);
+  if (allowedStages.length > 0 && !allowedStages.includes(stage)) return false;
+  const allowedStatuses = getAllowedStatusesForStage(stage, rules);
+  if (allowedStatuses.length > 0 && !allowedStatuses.includes(status)) return false;
+  return true;
+};

--- a/src/tui/update-dialog-submit.ts
+++ b/src/tui/update-dialog-submit.ts
@@ -1,3 +1,6 @@
+import type { StatusStageValidationRules } from './status-stage-validation.js';
+import { isStatusStageCompatible } from './status-stage-validation.js';
+
 export interface UpdateDialogItemState {
   status?: string;
   stage?: string;
@@ -28,10 +31,7 @@ export function buildUpdateDialogUpdates(
     stages: string[];
     priorities: string[];
   },
-  rules?: {
-    statusStage: Record<string, readonly string[]>;
-    stageStatus: Record<string, readonly string[]>;
-  }
+  rules?: StatusStageValidationRules
 ): UpdateDialogUpdatesResult {
   const updates: Record<string, string> = {};
 
@@ -39,18 +39,8 @@ export function buildUpdateDialogUpdates(
   const nextStage = resolveSelection(values.stages, selections.stageIndex);
   const nextPriority = resolveSelection(values.priorities, selections.priorityIndex);
 
-  const statusStageRules = rules?.statusStage ?? {};
-  const stageStatusRules = rules?.stageStatus ?? {};
-
-  if (nextStatus && nextStage) {
-    const allowedStages = statusStageRules[nextStatus];
-    const allowedStatuses = stageStatusRules[nextStage];
-    if (allowedStages && !allowedStages.includes(nextStage)) {
-      return { updates: {}, hasChanges: false };
-    }
-    if (allowedStatuses && !allowedStatuses.includes(nextStatus)) {
-      return { updates: {}, hasChanges: false };
-    }
+  if (!isStatusStageCompatible(nextStatus, nextStage, rules)) {
+    return { updates: {}, hasChanges: false };
   }
 
   if (nextStatus && nextStatus !== item.status) updates.status = nextStatus;

--- a/tests/tui/status-stage-validation.test.ts
+++ b/tests/tui/status-stage-validation.test.ts
@@ -1,0 +1,41 @@
+import { describe, it, expect } from 'vitest';
+import {
+  getAllowedStagesForStatus,
+  getAllowedStatusesForStage,
+  isStatusStageCompatible,
+} from '../../src/tui/status-stage-validation.js';
+import {
+  STATUS_STAGE_COMPATIBILITY,
+  STAGE_STATUS_COMPATIBILITY,
+} from '../../src/tui/status-stage-rules.js';
+
+describe('Status/Stage Validation Helper', () => {
+  const rules = {
+    statusStage: STATUS_STAGE_COMPATIBILITY,
+    stageStatus: STAGE_STATUS_COMPATIBILITY,
+  };
+
+  it('returns allowed stages for status', () => {
+    expect(getAllowedStagesForStatus('open', rules)).toEqual([
+      '',
+      'idea',
+      'prd_complete',
+      'plan_complete',
+      'in_progress',
+    ]);
+  });
+
+  it('returns allowed statuses for stage', () => {
+    expect(getAllowedStatusesForStage('in_review', rules)).toEqual(['completed']);
+  });
+
+  it('accepts valid status/stage pairs', () => {
+    expect(isStatusStageCompatible('completed', 'done', rules)).toBe(true);
+    expect(isStatusStageCompatible('blocked', 'idea', rules)).toBe(true);
+  });
+
+  it('rejects invalid status/stage pairs', () => {
+    expect(isStatusStageCompatible('completed', 'idea', rules)).toBe(false);
+    expect(isStatusStageCompatible('deleted', 'in_review', rules)).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary
- add a shared status/stage validation helper for TUI dialogs
- route update dialog and close flow through the shared helper
- add unit tests covering helper behavior

## Testing
- npm test -- --run tests/tui/status-stage-validation.test.ts tests/tui/tui-update-dialog.test.ts