### PR TITLE
WIP: Add next-next option to Next Item dialog (WL-0ML7BI9MJ1LP9CS9)

### DIFF
--- a/src/tui/components/help-menu.ts
+++ b/src/tui/components/help-menu.ts
@@ -156,6 +156,7 @@ export class HelpMenuComponent {
         items: [
           { keys: 'O', description: 'Open OpenCode prompt' },
           { keys: 'N', description: 'Find next work item' },
+          { keys: 'N (dialog)', description: 'Next recommendation' },
           { keys: 'X', description: 'Close selected item' },
           { keys: 'U', description: 'Update selected item' },
         ],


### PR DESCRIPTION
## Summary
- add a Next recommendation option and in-dialog N key to cycle through successive next items
- keep the dialog open and show a clear note when there are no further recommendations
- cover the flow with a TUI integration test and update help text

## Testing
- npm test