### PR TITLE
WIP: Add directional filtering to wl dep list (WL-0ML7BAIK01G7BRQR)

### DIFF
--- a/CLI.md
+++ b/CLI.md
@@ -139,6 +139,8 @@ Behavior:
 - `dep add` errors if the dependency already exists.
 - `dep rm` warns and exits 0 when ids are missing.
 - `dep list` warns and exits 0 when ids are missing.
+- `dep list --outgoing` shows only outbound dependencies.
+- `dep list --incoming` shows only inbound dependencies.
 
 Examples:
 

--- a/src/cli-types.ts
+++ b/src/cli-types.ts
@@ -109,4 +109,8 @@ export interface CloseOptions { reason?: string; author?: string; prefix?: strin
 
 export interface DeleteOptions { prefix?: string }
 
-export interface DepOptions { prefix?: string }
+export interface DepOptions {
+  prefix?: string;
+  incoming?: boolean;
+  outgoing?: boolean;
+}

--- a/tests/cli/issue-management.test.ts
+++ b/tests/cli/issue-management.test.ts
@@ -253,6 +253,44 @@ describe('CLI Issue Management Tests', () => {
       expect(result.inbound[0].direction).toBe('depended-on-by');
     });
 
+    it('should list outbound-only dependency edges', async () => {
+      const { stdout: fromStdout } = await execAsync(`tsx ${cliPath} --json create -t "From"`);
+      const { stdout: toStdout } = await execAsync(`tsx ${cliPath} --json create -t "To"`);
+      const { stdout: otherStdout } = await execAsync(`tsx ${cliPath} --json create -t "Other"`);
+      const fromId = JSON.parse(fromStdout).workItem.id;
+      const toId = JSON.parse(toStdout).workItem.id;
+      const otherId = JSON.parse(otherStdout).workItem.id;
+
+      await execAsync(`tsx ${cliPath} --json dep add ${fromId} ${toId}`);
+      await execAsync(`tsx ${cliPath} --json dep add ${otherId} ${fromId}`);
+
+      const { stdout } = await execAsync(`tsx ${cliPath} --json dep list ${fromId} --outgoing`);
+      const result = JSON.parse(stdout);
+      expect(result.success).toBe(true);
+      expect(result.outbound).toHaveLength(1);
+      expect(result.outbound[0].id).toBe(toId);
+      expect(result.inbound).toHaveLength(0);
+    });
+
+    it('should list inbound-only dependency edges', async () => {
+      const { stdout: fromStdout } = await execAsync(`tsx ${cliPath} --json create -t "From"`);
+      const { stdout: toStdout } = await execAsync(`tsx ${cliPath} --json create -t "To"`);
+      const { stdout: otherStdout } = await execAsync(`tsx ${cliPath} --json create -t "Other"`);
+      const fromId = JSON.parse(fromStdout).workItem.id;
+      const toId = JSON.parse(toStdout).workItem.id;
+      const otherId = JSON.parse(otherStdout).workItem.id;
+
+      await execAsync(`tsx ${cliPath} --json dep add ${fromId} ${toId}`);
+      await execAsync(`tsx ${cliPath} --json dep add ${otherId} ${fromId}`);
+
+      const { stdout } = await execAsync(`tsx ${cliPath} --json dep list ${fromId} --incoming`);
+      const result = JSON.parse(stdout);
+      expect(result.success).toBe(true);
+      expect(result.inbound).toHaveLength(1);
+      expect(result.inbound[0].id).toBe(otherId);
+      expect(result.outbound).toHaveLength(0);
+    });
+
     it('should warn for missing ids and exit 0 for list', async () => {
       const { stdout } = await execAsync(`tsx ${cliPath} --json dep list TEST-NOTFOUND`);
       const result = JSON.parse(stdout);
@@ -261,6 +299,20 @@ describe('CLI Issue Management Tests', () => {
       expect(result.warnings.length).toBeGreaterThan(0);
       expect(result.inbound).toHaveLength(0);
       expect(result.outbound).toHaveLength(0);
+    });
+
+    it('should error when using incoming and outgoing together', async () => {
+      const { stdout: fromStdout } = await execAsync(`tsx ${cliPath} --json create -t "From"`);
+      const fromId = JSON.parse(fromStdout).workItem.id;
+
+      try {
+        await execAsync(`tsx ${cliPath} --json dep list ${fromId} --incoming --outgoing`);
+        expect.fail('Should have thrown an error');
+      } catch (error: any) {
+        const result = JSON.parse(error.stderr || '{}');
+        expect(result.success).toBe(false);
+        expect(result.error).toBe('Cannot use --incoming and --outgoing together.');
+      }
     });
   });
 });


### PR DESCRIPTION
## Summary

- Adds `--outgoing` and `--incoming` flags to `wl dep list` with mutual-exclusion enforcement.
- Filters both JSON and human output to return only the requested direction.

## Files changed
- CLI.md
- src/cli-types.ts
- src/commands/dep.ts
- tests/cli/issue-management.test.ts

## Tests
- Unit tests covering outbound-only, inbound-only, both-flags error and default behavior were added and all tests pass locally (`npm test`).

## How to verify
1. Checkout branch `feature/WL-0ML7BAIK01G7BRQR-dep-list-direction`.
2. Run `npm test` to confirm all tests pass.
3. Try `wl dep list <id> --outgoing` and `--incoming` to observe filtered output.

## Reviewer notes
- Focus review on `src/commands/dep.ts` for direction filtering and on `tests/cli/issue-management.test.ts` for coverage.
- JSON output shape is unchanged; only the contents are filtered.

/cc WL-0ML7BAIK01G7BRQR