### PR TITLE
WL-0ML9BQA5X1S988GL: fix stats plugin check path

### DIFF
--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -6,6 +6,7 @@ import type { PluginContext } from '../plugin-types.js';
 import type { InitOptions } from '../cli-types.js';
 import type { DependencyEdge } from '../types.js';
 import { initConfig, loadConfig, configExists, isInitialized, readInitSemaphore, writeInitSemaphore, type InitConfigOptions } from '../config.js';
+import { resolveWorklogDir } from '../worklog-paths.js';
 import { exportToJsonl } from '../jsonl.js';
 import { getRemoteDataFileContent, gitPushDataFileToBranch, mergeWorkItems, mergeComments, mergeDependencyEdges } from '../sync.js';
 import { DEFAULT_GIT_REMOTE, DEFAULT_GIT_BRANCH } from '../sync-defaults.js';
@@ -624,8 +625,8 @@ async function ensureStatsPluginInstalled(options: { silent: boolean; overwrite?
   const templatePath = locateExampleStatsPlugin();
   if (!templatePath) return { installed: false, skipped: true, reason: 'template not found', templatePath: null, destinationPath: null };
 
-  const projectRoot = resolveProjectRoot();
-  const pluginsDir = path.join(projectRoot, '.worklog', 'plugins');
+  const worklogDir = resolveWorklogDir();
+  const pluginsDir = path.join(worklogDir, 'plugins');
   const destinationPath = path.join(pluginsDir, 'stats-plugin.mjs');
 
   try {


### PR DESCRIPTION
## Summary
- resolve stats plugin install/check path via worklog dir to avoid false positives in worktrees
- keep init plugin check aligned with .worklog resolution

## Testing
- npm test