### PR TITLE
WIP: Introduce centralized shutdown/cleanup flow (WL-0MKX63DS61P80NEK)

### DIFF
--- a/tests/tui/shutdown-flow.test.ts
+++ b/tests/tui/shutdown-flow.test.ts
@@ -1,0 +1,19 @@
+import { readFileSync } from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+import { describe, expect, it } from 'vitest';
+
+describe('TUI shutdown flow', () => {
+  it('uses shared shutdown helper and avoids direct process.exit', () => {
+    const testDir = path.dirname(fileURLToPath(import.meta.url));
+    const rootDir = path.resolve(testDir, '../..');
+    const tuiPath = path.join(rootDir, 'src/commands/tui.ts');
+    const source = readFileSync(tuiPath, 'utf8');
+
+    expect(source).toContain('const shutdown = () =>');
+    expect(source).not.toMatch(/process\.exit/);
+
+    const shutdownCalls = source.match(/shutdown\(\);/g) || [];
+    expect(shutdownCalls.length).toBeGreaterThanOrEqual(2);
+  });
+});


### PR DESCRIPTION
## Summary
- route TUI exit paths (q/C-c/escape) through shared shutdown helper
- ensure OpenCode server stop and pending timers clear before destroying screen
- add regression test enforcing no direct process.exit in TUI

## Testing
- npm test

## Reviewer notes
- verify shutdown helper covers all TUI exit paths
- confirm timer cleanup prevents lingering process