### PR TITLE
WL-0MLB5ZIOO0BDJJPG: improve CLI test stability

### DIFF
--- a/tests/ci-run.sh
+++ b/tests/ci-run.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+# Helper script to run tests in a serial fashion for CI environments
+set -euo pipefail
+
+echo "Running vitest with single worker"
+# Vitest doesn't accept --runInBand; using NODE_OPTIONS to limit workers can help in some environments
+VITEST_WORKER_THREADS=1 npx vitest run "$@"

--- a/tests/cli/status.test.ts
+++ b/tests/cli/status.test.ts
@@ -92,7 +92,7 @@ describe('CLI Status Tests', () => {
     expect(result.success).toBe(true);
     expect(result.database.workItems).toBe(2);
     expect(result.database.comments).toBe(1);
-  });
+  }, 60000);
 
   it('should output human-readable format by default', async () => {
     fs.writeFileSync(


### PR DESCRIPTION
## Summary\nIncrease stability of CLI tests by adding a CI-serial run helper and increasing timeout for a long-running test.\n\n## Changes\n- tests/cli/status.test.ts: add per-test timeout for the slow database-counts test\n- tests/ci-run.sh: new helper script to run vitest with single worker for CI\n\n## Verification\n- Ran full test-suite locally; all tests passed.\n- Branch: wl-WL-0MLB5ZIOO0BDJJPG-fix-cli-test-timeouts\n\nRelated work item: WL-0MLB5ZIOO0BDJJPG\n,