### PR TITLE
TUI search should match work item IDs (WL-0MLBVDSWR1U7R01E)

### DIFF
--- a/src/commands/list.ts
+++ b/src/commands/list.ts
@@ -13,7 +13,7 @@ export default function register(ctx: PluginContext): void {
   program
     .command('list')
     .description('List work items')
-    .argument('[search]', 'Search term (matches title and description)')
+    .argument('[search]', 'Search term (matches id, title, and description)')
     .option('-s, --status <status>', 'Filter by status')
     .option('-p, --priority <priority>', 'Filter by priority')
     .option('--parent <id>', 'Filter by parent id (direct children only)')
@@ -62,9 +62,10 @@ export default function register(ctx: PluginContext): void {
       if (search) {
         const lower = String(search).toLowerCase();
         items = items.filter(item => {
+          const idMatch = item.id && item.id.toLowerCase().includes(lower);
           const titleMatch = item.title && item.title.toLowerCase().includes(lower);
           const descMatch = item.description && item.description.toLowerCase().includes(lower);
-          return Boolean(titleMatch || descMatch);
+          return Boolean(idMatch || titleMatch || descMatch);
         });
       }
       

--- a/src/database.ts
+++ b/src/database.ts
@@ -977,10 +977,11 @@ export class WorklogDatabase {
       filtered = filtered.filter(item => item.assignee === assignee);
     }
 
-    // Filter by search term if provided (fuzzy match against title, description, and comments)
+    // Filter by search term if provided (fuzzy match against id, title, description, and comments)
     if (searchTerm) {
       const lowerSearchTerm = searchTerm.toLowerCase();
       filtered = filtered.filter(item => {
+        const idMatch = item.id.toLowerCase().includes(lowerSearchTerm);
         // Check title and description
         const titleMatch = item.title.toLowerCase().includes(lowerSearchTerm);
         const descriptionMatch = item.description?.toLowerCase().includes(lowerSearchTerm) || false;
@@ -991,7 +992,7 @@ export class WorklogDatabase {
           comment.comment.toLowerCase().includes(lowerSearchTerm)
         );
         
-        return titleMatch || descriptionMatch || commentMatch;
+        return idMatch || titleMatch || descriptionMatch || commentMatch;
       });
     }
 

--- a/tests/cli/issue-status.test.ts
+++ b/tests/cli/issue-status.test.ts
@@ -67,6 +67,18 @@ describe('CLI Issue Status Tests', () => {
       expect(result.workItems[0].priority).toBe('high');
     });
 
+    it('should filter by id search term', async () => {
+      const { stdout: createStdout } = await execAsync(`tsx ${cliPath} --json create -t "Searchable"`);
+      const created = JSON.parse(createStdout).workItem;
+
+      const { stdout } = await execAsync(`tsx ${cliPath} --json list ${created.id}`);
+      const result = JSON.parse(stdout);
+
+      const ids = result.workItems.map((item: any) => item.id);
+      expect(result.success).toBe(true);
+      expect(ids).toContain(created.id);
+    });
+
     it('should filter by parent id', async () => {
       const parentResult = await execAsync(`tsx ${cliPath} --json create -t "Parent"`);
       const parent = JSON.parse(parentResult.stdout).workItem;

--- a/tests/database.test.ts
+++ b/tests/database.test.ts
@@ -584,6 +584,15 @@ describe('WorklogDatabase', () => {
       expect(result.workItem?.id).toBe(searchItem.id);
     });
 
+    it('should filter by search term in id', () => {
+      const target = db.create({ title: 'Target', priority: 'low', status: 'open' });
+      db.create({ title: 'Other', priority: 'critical', status: 'open' });
+
+      const idFragment = target.id.slice(-6).toLowerCase();
+      const result = db.findNextWorkItem(undefined, idFragment);
+      expect(result.workItem?.id).toBe(target.id);
+    });
+
     it('should return in-progress item if it has no suitable children', () => {
       const parent = db.create({ title: 'Parent', priority: 'high', status: 'in-progress' });
       db.create({ title: 'Completed child', priority: 'high', status: 'completed', parentId: parent.id });


### PR DESCRIPTION
## Summary
- extend CLI list search (used by TUI '/') to match work item IDs
- align database search filtering to include IDs
- add CLI and database tests for ID search

## Testing
- npm test

## Reviewer Notes
- focus on src/commands/list.ts search logic and new CLI test coverage