### PR TITLE
WL-0MLC3SUXI0QI9I3L: gate blocked in_review in wl next

### DIFF
--- a/CLI.md
+++ b/CLI.md
@@ -183,7 +183,7 @@ Options:
 `-a, --assignee <assignee>` (optional)
 `-s, --search <term>` (optional)
 `-n, --number <n>` — Number of items to return (optional; default: `1`).
-`--include-in-review` — Include items with stage `in_review` (optional).
+`--include-in-review` — Include items with status `blocked` and stage `in_review` (optional).
 `--prefix <prefix>` (optional)
 
 Examples:

--- a/docs/validation/status-stage-inventory.md
+++ b/docs/validation/status-stage-inventory.md
@@ -58,7 +58,7 @@ Adding/removing dependency edges affects status based on the dependency stage.
 
 ## Selection/Filtering Rules (Implied)
 The next-item selection logic treats in_review specially and filters statuses.
-- Exclude stage=in_review by default (unless --include-in-review)
+- Exclude status=blocked and stage=in_review by default (unless --include-in-review)
   - Source: src/commands/next.ts (option), src/database.ts (findNextWorkItemFromItems)
 - Filter out status=deleted in next-item selection
   - Source: src/database.ts (findNextWorkItemFromItems)

--- a/src/commands/next.ts
+++ b/src/commands/next.ts
@@ -18,7 +18,7 @@ export default function register(ctx: PluginContext): void {
     .option('-n, --number <n>', 'Number of items to return (default: 1)', '1')
     .option('--recency-policy <policy>', 'Recency policy: prefer|avoid|ignore (default: ignore)', 'ignore')
     .option('--prefix <prefix>', 'Override the default prefix')
-    .option('--include-in-review', 'Include items with stage in_review (default: excluded)')
+    .option('--include-in-review', 'Include items with status blocked and stage in_review (default: excluded)')
     .action(async (options: any) => {
       utils.requireInitialized();
       const db = utils.getDatabase(options.prefix);

--- a/src/database.ts
+++ b/src/database.ts
@@ -715,7 +715,9 @@ export class WorklogDatabase {
     // Exclude epics from being recommended by `wl next` by default
     filteredItems = filteredItems.filter(item => item.issueType !== 'epic');
     if (!includeInReview) {
-      filteredItems = filteredItems.filter(item => item.stage !== 'in_review');
+      filteredItems = filteredItems.filter(
+        item => !(item.stage === 'in_review' && item.status === 'blocked')
+      );
     }
     if (excluded && excluded.size > 0) {
       filteredItems = filteredItems.filter(item => !excluded.has(item.id));

--- a/tests/database.test.ts
+++ b/tests/database.test.ts
@@ -528,21 +528,21 @@ describe('WorklogDatabase', () => {
       expect(result.workItem?.id).toBe(openItem.id);
     });
 
-    it('should exclude in_review items by default', () => {
-      const inReview = db.create({ title: 'In review', status: 'open', stage: 'in_review', priority: 'high' });
+    it('should exclude blocked in_review items by default', () => {
+      const inReviewBlocked = db.create({ title: 'In review', status: 'blocked', stage: 'in_review', priority: 'high' });
       const openItem = db.create({ title: 'Open', status: 'open', priority: 'low' });
 
       const result = db.findNextWorkItem();
       expect(result.workItem?.id).toBe(openItem.id);
-      expect(result.workItem?.id).not.toBe(inReview.id);
+      expect(result.workItem?.id).not.toBe(inReviewBlocked.id);
     });
 
-    it('should include in_review items when requested', () => {
-      const inReview = db.create({ title: 'In review', status: 'open', stage: 'in_review', priority: 'high' });
+    it('should include blocked in_review items when requested', () => {
+      const inReviewBlocked = db.create({ title: 'In review', status: 'blocked', stage: 'in_review', priority: 'high' });
       db.create({ title: 'Open', status: 'open', priority: 'low' });
 
       const result = db.findNextWorkItem(undefined, undefined, 'ignore', true);
-      expect(result.workItem?.id).toBe(inReview.id);
+      expect(result.workItem?.id).toBe(inReviewBlocked.id);
     });
 
     it('should filter by assignee when provided', () => {


### PR DESCRIPTION
## Summary
- exclude items with status=blocked and stage=in_review from wl next unless --include-in-review is set
- update CLI/docs to describe the flag behavior
- adjust database tests for default exclusion and explicit inclusion

## Testing
- npm test