### PR TITLE
Refactor persistence: replace sync fs calls with async layer (WL-0MKX5ZUWF1MZCJNU)

### DIFF
--- a/src/commands/tui.ts
+++ b/src/commands/tui.ts
@@ -30,7 +30,7 @@ export default function register(ctx: PluginContext): void {
     .option('--in-progress', 'Show only in-progress items')
     .option('--all', 'Include completed/deleted items in the list')
     .option('--prefix <prefix>', 'Override the default prefix')
-    .action((options: { inProgress?: boolean; prefix?: string; all?: boolean }) => {
-      controller.start(options);
+    .action(async (options: { inProgress?: boolean; prefix?: string; all?: boolean }) => {
+      await controller.start(options);
     });
 }

--- a/src/tui/persistence.ts
+++ b/src/tui/persistence.ts
@@ -1,17 +1,26 @@
 import * as fs from 'fs';
 import * as path from 'path';
 
-export type FsLike = Pick<typeof fs, 'existsSync' | 'readFileSync' | 'writeFileSync' | 'mkdirSync'>;
+export type FsLike = Pick<typeof fs.promises, 'access' | 'readFile' | 'writeFile' | 'mkdir'>;
 
 export function createPersistence(worklogDir: string, opts?: { fs?: FsLike; debugLog?: (msg: string) => void }) {
-  const fsImpl: FsLike = opts?.fs ?? fs;
+  const fsImpl: FsLike = opts?.fs ?? fs.promises;
   const debugLog = opts?.debugLog ?? (() => {});
   const statePath = path.join(worklogDir, 'tui-state.json');
 
-  function loadPersistedState(prefix?: string) {
+  const fileExists = async (target: string) => {
     try {
-      if (!fsImpl.existsSync(statePath)) return null;
-      const raw = fsImpl.readFileSync(statePath, 'utf8');
+      await fsImpl.access(target);
+      return true;
+    } catch (_) {
+      return false;
+    }
+  };
+
+  async function loadPersistedState(prefix?: string) {
+    try {
+      if (!(await fileExists(statePath))) return null;
+      const raw = await fsImpl.readFile(statePath, 'utf8');
       const j = JSON.parse(raw || '{}');
       const val = j[prefix || 'default'] || null;
       debugLog(`loadPersistedState prefix=${String(prefix || 'default')} path=${statePath} present=${val !== null}`);
@@ -22,15 +31,15 @@ export function createPersistence(worklogDir: string, opts?: { fs?: FsLike; debu
     }
   }
 
-  function savePersistedState(prefix: string | undefined, state: any) {
+  async function savePersistedState(prefix: string | undefined, state: any) {
     try {
-      if (!fsImpl.existsSync(worklogDir)) fsImpl.mkdirSync(worklogDir, { recursive: true });
+      await fsImpl.mkdir(worklogDir, { recursive: true });
       let j: any = {};
-      if (fsImpl.existsSync(statePath)) {
-        try { j = JSON.parse(fsImpl.readFileSync(statePath, 'utf8') || '{}'); } catch { j = {}; }
+      if (await fileExists(statePath)) {
+        try { j = JSON.parse(await fsImpl.readFile(statePath, 'utf8') || '{}'); } catch { j = {}; }
       }
       j[prefix || 'default'] = state;
-      fsImpl.writeFileSync(statePath, JSON.stringify(j, null, 2), 'utf8');
+      await fsImpl.writeFile(statePath, JSON.stringify(j, null, 2), 'utf8');
       try {
         const keys = Object.keys(state || {}).join(',');
         debugLog(`savePersistedState prefix=${String(prefix || 'default')} path=${statePath} keys=[${keys}]`);

--- a/tests/tui/controller.test.ts
+++ b/tests/tui/controller.test.ts
@@ -63,7 +63,7 @@ const makeScreen = () => {
 };
 
 describe('TuiController', () => {
-  it('starts with injected deps and layout', () => {
+  it('starts with injected deps and layout', async () => {
     const screen = makeScreen();
     const list = makeList();
     const footer = makeBox();
@@ -183,13 +183,13 @@ describe('TuiController', () => {
       OpencodeClient: FakeOpencodeClient as any,
       resolveWorklogDir: () => '/tmp',
       createPersistence: () => ({
-        loadPersistedState: () => null,
-        savePersistedState: () => undefined,
+        loadPersistedState: async () => null,
+        savePersistedState: async () => undefined,
         statePath: '/tmp/tui-state.json',
       }),
     });
 
-    controller.start({});
+    await controller.start({});
 
     expect(createLayout).toHaveBeenCalled();
     expect(opencodeCtorCalls.length).toBe(1);

--- a/tests/tui/event-cleanup.test.ts
+++ b/tests/tui/event-cleanup.test.ts
@@ -49,7 +49,7 @@ describe('OpencodeClient SSE cleanup', () => {
         confirmTextbox: async () => true,
       },
       render: () => {},
-      persistedState: { load: () => ({}), save: () => {}, getPrefix: () => undefined },
+      persistedState: { load: async () => ({}), save: async () => {}, getPrefix: () => undefined },
       httpImpl: httpImpl,
       spawnImpl: (name: string) => { throw new Error('not used'); },
     } as any);

--- a/tests/tui/filter.test.ts
+++ b/tests/tui/filter.test.ts
@@ -92,7 +92,7 @@ describe("TUI '/' search/filter", () => {
     register(ctx);
 
     // simulate running command
-    program.parse(['tui'], { from: 'user' });
+    await program.parseAsync(['tui'], { from: 'user' });
 
     // Find the screen.key registration for '/'
     // We can't easily invoke the internal key handler, but ensure module loads without error
@@ -126,7 +126,7 @@ describe("TUI '/' search/filter", () => {
 
     const register = (await import('../../src/commands/tui.js')).default;
     register(ctx);
-    program.parse(['tui'], { from: 'user' });
+    await program.parseAsync(['tui'], { from: 'user' });
 
     // Trigger the '/' key handler registered on the screen
     const screen = (blessedImpl.screen as any)();

--- a/tests/tui/next-dialog-wrap.test.ts
+++ b/tests/tui/next-dialog-wrap.test.ts
@@ -163,7 +163,7 @@ describe('next dialog text wrapping', () => {
     const register = (await import('../../src/commands/tui.js')).default;
     register(ctx);
 
-    program.parse(['tui'], { from: 'user' });
+    await program.parseAsync(['tui'], { from: 'user' });
 
     const nextDialogTextCall = blessedImpl.box.mock.calls.find(
       (call) => call[0]?.content === 'Evaluating next work item...'

--- a/tests/tui/opencode-child-lifecycle.test.ts
+++ b/tests/tui/opencode-child-lifecycle.test.ts
@@ -35,7 +35,7 @@ describe('OpencodeClient child process lifecycle', () => {
       showToast: () => {},
       modalDialogs: { selectList: async () => null, editTextarea: async () => null, confirmTextbox: async () => true },
       render: () => {},
-      persistedState: { load: () => ({}), save: () => {}, getPrefix: () => undefined },
+      persistedState: { load: async () => ({}), save: async () => {}, getPrefix: () => undefined },
       httpImpl: {} as any,
       spawnImpl,
     } as any);

--- a/tests/tui/opencode-prompt-input.test.ts
+++ b/tests/tui/opencode-prompt-input.test.ts
@@ -71,7 +71,7 @@ const makeScreen = () => ({
 });
 
 describe('OpenCode prompt input modes', () => {
-  it('supports normal/insert mode and cursor movement without inserting', () => {
+  it('supports normal/insert mode and cursor movement without inserting', async () => {
     const screen = makeScreen();
     const list = makeList();
     const footer = makeBox();
@@ -185,13 +185,13 @@ describe('OpenCode prompt input modes', () => {
       OpencodeClient: FakeOpencodeClient as any,
       resolveWorklogDir: () => '/tmp',
       createPersistence: () => ({
-        loadPersistedState: () => null,
-        savePersistedState: () => undefined,
+        loadPersistedState: async () => null,
+        savePersistedState: async () => undefined,
         statePath: '/tmp/tui-state.json',
       }),
     });
 
-    controller.start({});
+    await controller.start({});
 
     const inputHandler = (opencodeText as any)._listener as (ch: any, key: any) => void;
     expect(typeof inputHandler).toBe('function');

--- a/tests/tui/opencode-session-selection.test.ts
+++ b/tests/tui/opencode-session-selection.test.ts
@@ -61,7 +61,7 @@ const makeClient = (httpImpl: any, persistedState: any) => {
 describe('OpencodeClient session selection', () => {
   it('prefers the current session when ids match', async () => {
     const httpImpl = makeHttpMock({});
-    const persistedState = { load: () => ({}), save: vi.fn(), getPrefix: () => undefined };
+    const persistedState = { load: async () => ({}), save: vi.fn().mockResolvedValue(undefined), getPrefix: () => undefined };
     const client = makeClient(httpImpl as any, persistedState);
 
     (client as any).currentSessionId = 'WL-123';
@@ -75,8 +75,8 @@ describe('OpencodeClient session selection', () => {
       'GET /session/:id': () => ({ statusCode: 200, body: '' }),
     });
     const persistedState = {
-      load: () => ({ sessionMap: { 'WL-1': 'sess-1' } }),
-      save: vi.fn(),
+      load: async () => ({ sessionMap: { 'WL-1': 'sess-1' } }),
+      save: vi.fn().mockResolvedValue(undefined),
       getPrefix: () => undefined,
     };
     const client = makeClient(httpImpl as any, persistedState);
@@ -94,8 +94,8 @@ describe('OpencodeClient session selection', () => {
       }),
     });
     const persistedState = {
-      load: () => ({ sessionMap: { 'WL-1': 'stale' } }),
-      save: vi.fn(),
+      load: async () => ({ sessionMap: { 'WL-1': 'stale' } }),
+      save: vi.fn().mockResolvedValue(undefined),
       getPrefix: () => undefined,
     };
     const client = makeClient(httpImpl as any, persistedState);
@@ -113,7 +113,7 @@ describe('OpencodeClient session selection', () => {
         body: JSON.stringify({ id: 'sess-3', title: 'workitem:WL-1 TUI Session' }),
       }),
     });
-    const persistedState = { load: () => ({}), save: vi.fn(), getPrefix: () => undefined };
+    const persistedState = { load: async () => ({}), save: vi.fn().mockResolvedValue(undefined), getPrefix: () => undefined };
     const client = makeClient(httpImpl as any, persistedState);
 
     const result = await (client as any).createSession('WL-1');

--- a/tests/tui/opencode-sse.test.ts
+++ b/tests/tui/opencode-sse.test.ts
@@ -47,7 +47,7 @@ describe('OpencodeClient SSE event handling', () => {
     showToast: () => {},
     modalDialogs: { selectList: async () => null, editTextarea: async () => null, confirmTextbox: async () => true },
     render: () => {},
-    persistedState: { load: () => ({}), save: () => {}, getPrefix: () => undefined },
+    persistedState: { load: async () => ({}), save: async () => {}, getPrefix: () => undefined },
     httpImpl: {} as any,
     spawnImpl: () => { throw new Error('not used'); },
   } as any);


### PR DESCRIPTION
## Summary
- replace TUI persistence sync fs calls with async fs.promises wrapper
- await initial persisted state load and make subsequent saves non-blocking
- update persisted state handling in Opencode client and TUI tests to async

## Testing
- npm test