### PR TITLE
Prompt input box must resize on word wrap (WL-0MKXJPCDI1FLYDB1)

### DIFF
--- a/docs/opencode-tui.md
+++ b/docs/opencode-tui.md
@@ -57,6 +57,12 @@ The Worklog TUI now includes full integration with OpenCode, an AI-powered codin
 - User responses are shown in cyan in the conversation
 - Press Escape to cancel input mode
 
+### 7. Prompt Input Auto-Resize
+
+- The prompt input box grows as long lines wrap within the terminal
+- Auto-resize caps at a maximum height; beyond that, the input scrolls
+- Manual resize via `Ctrl+Enter` still works when adding explicit newlines
+
 ## Usage
 
 ### Starting a Conversation


### PR DESCRIPTION
## Summary
- Auto-resize OpenCode prompt input based on wrapped visual lines and keep scroll-at-max-height behavior.
- Maintain Ctrl+Enter manual resize and document the input auto-resize behavior.
- Add a test covering wrapped-line auto-resize behavior.
## Testing
- npm test
## Review Notes
- Focus on the input height calculation based on `_clines` and the scroll-to-bottom behavior.