### PR TITLE
Expand in-progress nodes on refresh (WL-0MKW0MW1O1VFI2WZ)

### DIFF
--- a/src/commands/tui.ts
+++ b/src/commands/tui.ts
@@ -10,6 +10,7 @@ import {
   buildVisibleNodes as state_buildVisibleNodes,
   filterVisibleItems as state_filterVisibleItems,
   isClosedStatus as state_isClosedStatus,
+  expandAncestorsForInProgress as state_expandAncestorsForInProgress,
 } from '../tui/state.js';
 import type { TuiState } from '../tui/state.js';
 
@@ -18,6 +19,7 @@ export const filterVisibleItems = state_filterVisibleItems;
 export const rebuildTreeState = state_rebuildTreeState;
 export const createTuiState = state_createTuiState;
 export const buildVisibleNodes = state_buildVisibleNodes;
+export const expandAncestorsForInProgress = state_expandAncestorsForInProgress;
 export type { TuiState };
 
 export default function register(ctx: PluginContext): void {

--- a/src/tui/state.ts
+++ b/src/tui/state.ts
@@ -80,3 +80,17 @@ export const buildVisibleNodes = (state: TuiState): VisibleNode[] => {
   for (const r of state.roots) visit(r, 0);
   return out;
 };
+
+export const expandAncestorsForInProgress = (state: TuiState): void => {
+  const inProgressItems = state.currentVisibleItems.filter((item) => {
+    const status = typeof item.status === 'string' ? item.status.replace(/_/g, '-') : item.status;
+    return status === 'in-progress';
+  });
+  for (const item of inProgressItems) {
+    let cursor = item;
+    while (cursor.parentId && state.itemsById.has(cursor.parentId)) {
+      state.expanded.add(cursor.parentId);
+      cursor = state.itemsById.get(cursor.parentId) as Item;
+    }
+  }
+};

--- a/tests/tui/tui-state.test.ts
+++ b/tests/tui/tui-state.test.ts
@@ -4,6 +4,7 @@ import {
   createTuiState,
   rebuildTreeState,
   filterVisibleItems,
+  expandAncestorsForInProgress,
 } from '../../src/commands/tui.js';
 
 type Item = {
@@ -81,5 +82,36 @@ describe('tui state helpers', () => {
     state.expanded.add('WL-1');
     const expanded = buildVisibleNodes(state);
     expect(expanded.map(node => node.item.id)).toEqual(['WL-1', 'WL-2', 'WL-3']);
+  });
+
+  it('expands ancestors for in-progress items', () => {
+    const items = [
+      makeItem('WL-1', 'open'),
+      makeItem('WL-2', 'in-progress', 'WL-1'),
+      makeItem('WL-3', 'open', 'WL-2'),
+    ];
+
+    const state = createTuiState(items as any, true, []);
+    rebuildTreeState(state);
+
+    expandAncestorsForInProgress(state);
+
+    expect(state.expanded.has('WL-1')).toBe(true);
+    expect(state.expanded.has('WL-2')).toBe(false);
+  });
+
+  it('expands ancestors when status uses underscore form', () => {
+    const items = [
+      makeItem('WL-1', 'open'),
+      { ...makeItem('WL-2', 'open', 'WL-1'), status: 'in_progress' },
+      makeItem('WL-3', 'open', 'WL-2'),
+    ];
+
+    const state = createTuiState(items as any, true, []);
+    rebuildTreeState(state);
+
+    expandAncestorsForInProgress(state);
+
+    expect(state.expanded.has('WL-1')).toBe(true);
   });
 });


### PR DESCRIPTION
## Summary
- expand ancestor nodes for in-progress items on TUI refresh/start so they stay visible
- normalize in_progress vs in-progress status when computing expansion targets
- add state tests covering in-progress expansion and underscore status

## Testing
- npm test