### PR TITLE
WL-0MLDIFLCR1REKNGA: prevent deleted items from resurfacing

### DIFF
--- a/src/commands/delete.ts
+++ b/src/commands/delete.ts
@@ -10,7 +10,7 @@ export default function register(ctx: PluginContext): void {
   
   program
     .command('delete <id>')
-    .description('Delete a work item')
+    .description('Delete a work item (marks as deleted)')
     .option('--prefix <prefix>', 'Override the default prefix')
     .action((id: string, options: DeleteOptions) => {
       utils.requireInitialized();

--- a/src/database.ts
+++ b/src/database.ts
@@ -404,12 +404,22 @@ export class WorklogDatabase {
    */
   delete(id: string): boolean {
     this.refreshFromJsonlIfNewer();
-    const result = this.store.deleteWorkItem(id);
-    if (result) {
-      this.exportToJsonl();
-      this.triggerAutoSync();
+    const item = this.store.getWorkItem(id);
+    if (!item) {
+      return false;
     }
-    return result;
+
+    const updated: WorkItem = {
+      ...item,
+      status: 'deleted',
+      stage: '',
+      updatedAt: new Date().toISOString(),
+    };
+
+    this.store.saveWorkItem(updated);
+    this.exportToJsonl();
+    this.triggerAutoSync();
+    return true;
   }
 
   /**

--- a/tests/cli/issue-management.test.ts
+++ b/tests/cli/issue-management.test.ts
@@ -97,15 +97,11 @@ describe('CLI Issue Management Tests', () => {
       expect(result.success).toBe(true);
       expect(result.deletedId).toBe(workItemId);
 
-      try {
-        await execAsync(`tsx ${cliPath} --json show ${workItemId}`);
-        expect.fail('Should have thrown an error');
-      } catch (error: any) {
-        if (error?.stderr) {
-          const result = JSON.parse(error.stderr || '{}');
-          expect(result.success).toBe(false);
-        }
-      }
+      const { stdout: showStdout } = await execAsync(`tsx ${cliPath} --json show ${workItemId}`);
+      const shown = JSON.parse(showStdout);
+      expect(shown.success).toBe(true);
+      expect(shown.workItem.status).toBe('deleted');
+      expect(shown.workItem.stage).toBe('');
     });
   });
 

--- a/tests/database.test.ts
+++ b/tests/database.test.ts
@@ -211,7 +211,10 @@ describe('WorklogDatabase', () => {
       const deleted = db.delete(item.id);
 
       expect(deleted).toBe(true);
-      expect(db.get(item.id)).toBe(null);
+      const updated = db.get(item.id);
+      expect(updated).not.toBe(null);
+      expect(updated?.status).toBe('deleted');
+      expect(updated?.stage).toBe('');
     });
 
     it('should return false for non-existent ID', () => {


### PR DESCRIPTION
## Summary
- switch CLI delete to soft-delete by marking status=deleted and clearing stage
- keep deleted items in JSONL so refresh/merge cannot resurrect them
- update delete-related tests to assert deleted status instead of missing items

## Testing
- npx vitest run --testTimeout 60000