### PR TITLE
Update dialog not updating record (WL-0MLFURRPW0K02R52)

### DIFF
--- a/src/tui/controller.ts
+++ b/src/tui/controller.ts
@@ -2917,7 +2917,10 @@ export class TuiController {
         showToast('Updated');
         refreshFromDatabase(Math.max(0, (list.selected as number) - 0));
       } catch (err) {
-        showToast('Update failed');
+        const message = err instanceof Error
+          ? err.message
+          : (typeof err === 'string' ? err : 'Update failed');
+        showToast(message || 'Update failed');
       }
 
       closeUpdateDialog();

--- a/src/tui/update-dialog-submit.ts
+++ b/src/tui/update-dialog-submit.ts
@@ -43,13 +43,16 @@ export function buildUpdateDialogUpdates(
   const nextStatus = resolveSelection(values.statuses, selections.statusIndex);
   const nextStage = resolveSelection(values.stages, selections.stageIndex);
   const nextPriority = resolveSelection(values.priorities, selections.priorityIndex);
+  const compatibilityStage = nextStage === '' && item.stage === '' ? undefined : nextStage;
 
-  if (!isStatusStageCompatible(nextStatus, nextStage, rules)) {
+  if (!isStatusStageCompatible(nextStatus, compatibilityStage, rules)) {
     return { updates: {}, hasChanges: false };
   }
 
   if (nextStatus && nextStatus !== item.status) updates.status = nextStatus;
-  if (nextStage && nextStage !== item.stage) updates.stage = nextStage;
+  if (nextStage !== undefined && (nextStage === '' || nextStage !== item.stage)) {
+    updates.stage = nextStage;
+  }
   if (nextPriority && nextPriority !== item.priority) updates.priority = nextPriority;
 
   // Handle optional comment field. The UI may provide a multiline textbox


### PR DESCRIPTION
## Summary
- keep update dialog submissions when stage is blank by adjusting compatibility validation
- allow empty stage updates and preserve them in the update payload
- surface update failure messages in the toast and extend tests

## Testing
- npm test