### PR TITLE
Default stage to idea (WL-0MLFUSQDS1Z0TEF4)

### DIFF
--- a/docs/validation/status-stage-inventory.md
+++ b/docs/validation/status-stage-inventory.md
@@ -24,8 +24,8 @@ validation helpers and UI wiring.
     - in_progress
     - in_review
     - done
-  - Defaulting behavior on create/import: blank stage
-    - Source: src/database.ts (create) and src/jsonl.ts (import default)
+  - Defaulting behavior on create/import: idea for CLI create, blank stage on import
+    - Source: src/commands/create.ts (CLI default), src/jsonl.ts (import default)
 
 ## Compatibility Rules (Explicit)
 ### Status -> Allowed Stages

--- a/src/commands/create.ts
+++ b/src/commands/create.ts
@@ -47,15 +47,16 @@ export default function register(ctx: PluginContext): void {
       }
 
       const config = utils.getConfig();
+      const requestedStage = options.stage !== undefined ? options.stage : 'idea';
       let normalizedStatus = (options.status || 'open') as WorkItemStatus;
-      let normalizedStage = options.stage || '';
+      let normalizedStage = requestedStage;
       if (canValidateStatusStage(config)) {
         let warnings: string[] = [];
         try {
           const validation = validateStatusStageInput(
             {
               status: options.status || 'open',
-              stage: options.stage || '',
+              stage: requestedStage,
             },
             config
           );

--- a/tests/cli/issue-management.test.ts
+++ b/tests/cli/issue-management.test.ts
@@ -32,6 +32,7 @@ describe('CLI Issue Management Tests', () => {
       expect(result.workItem.title).toBe('Test task');
       expect(result.workItem.status).toBe('open');
       expect(result.workItem.priority).toBe('medium');
+      expect(result.workItem.stage).toBe('idea');
     });
 
     it('should create a work item with all optional fields', async () => {
@@ -170,7 +171,7 @@ describe('CLI Issue Management Tests', () => {
       const shown = JSON.parse(showStdout);
       expect(shown.success).toBe(true);
       expect(shown.workItem.status).toBe('deleted');
-      expect(shown.workItem.stage).toBe('');
+      expect(shown.workItem.stage).toBe('idea');
     });
   });
 


### PR DESCRIPTION
## Summary
- default wl create stage to idea when --stage is omitted
- keep status/stage validation behavior unchanged
- update CLI tests and validation inventory doc

## Testing
- npm test

## Review Notes
- Focus on CLI create defaulting behavior in src/commands/create.ts
- Confirm tests and docs reflect the default stage change