### PR TITLE
WL-0MLG0DKQZ06WDS2U: Atomic JSONL export + DB metadata handshake

### DIFF
--- a/tests/jsonl.test.ts
+++ b/tests/jsonl.test.ts
@@ -121,6 +121,24 @@ describe('JSONL Import/Export', () => {
       const content = fs.readFileSync(testFilePath, 'utf-8');
       expect(content).toBe('\n');
     });
+
+    it('should return file mtime and not leave temporary files behind', () => {
+      const items: WorkItem[] = [];
+      const comments: Comment[] = [];
+
+      const mtime = exportToJsonl(items, comments, testFilePath);
+
+      expect(typeof mtime).toBe('number');
+      const stats = fs.statSync(testFilePath);
+      expect(mtime).toBe(stats.mtimeMs);
+
+      // Ensure no temp files remain (pattern: <basename>.tmp-<random>)
+      const dir = path.dirname(testFilePath);
+      const base = path.basename(testFilePath);
+      const files = fs.readdirSync(dir);
+      const hasTemp = files.some(f => f.startsWith(base + '.tmp-'));
+      expect(hasTemp).toBe(false);
+    });
   });
 
   describe('importFromJsonl', () => {


### PR DESCRIPTION
Make JSONL exports atomic (temp file + rename) and record export metadata in the SQLite DB so processes can avoid re-import loops.\n\nChanges:\n- atomic JSONL writes in  (temp file + rename)\n- DB records  and  in \n-  skips re-import if JSONL matches last export mtime\n- preserve work item  on delete to avoid regressions\n- tests: ,  covering mtime and metadata\n\nTests: ran locally; new tests pass.