### PR TITLE
WL-0MLCX6PP81TQ70AH: instrument GitHub push hotspots

### DIFF
--- a/src/commands/github.ts
+++ b/src/commands/github.ts
@@ -116,6 +116,10 @@ export default function register(ctx: PluginContext): void {
         }
         logLine(`Timing totalMs=${timing.totalMs} upsertMs=${timing.upsertMs} commentListMs=${timing.commentListMs} commentUpsertMs=${timing.commentUpsertMs}`);
         logLine(`Timing hierarchyCheckMs=${timing.hierarchyCheckMs} hierarchyLinkMs=${timing.hierarchyLinkMs} hierarchyVerifyMs=${timing.hierarchyVerifyMs}`);
+        // If metrics were recorded, log them as well
+        const metrics = (timing as any).__metrics || {};
+        const metricPairs = Object.keys(metrics).map(k => `${k}=${metrics[k]}`);
+        if (metricPairs.length > 0) logLine(`Metrics ${metricPairs.join(' ')}`);
 
         if (isJsonMode) {
           output.json({ success: true, ...result, repo: githubConfig.repo });
@@ -132,16 +136,24 @@ export default function register(ctx: PluginContext): void {
             console.log(`  Errors: ${result.errors.length}`);
             console.log('  Hint: re-run with --json to view error details');
           }
-          if (isVerbose) {
-            console.log('  Timing breakdown:');
-            console.log(`    Total: ${(timing.totalMs / 1000).toFixed(2)}s`);
-            console.log(`    Issue upserts: ${(timing.upsertMs / 1000).toFixed(2)}s`);
-            console.log(`    Comment list: ${(timing.commentListMs / 1000).toFixed(2)}s`);
-            console.log(`    Comment upserts: ${(timing.commentUpsertMs / 1000).toFixed(2)}s`);
-            console.log(`    Hierarchy check: ${(timing.hierarchyCheckMs / 1000).toFixed(2)}s`);
-            console.log(`    Hierarchy link: ${(timing.hierarchyLinkMs / 1000).toFixed(2)}s`);
-            console.log(`    Hierarchy verify: ${(timing.hierarchyVerifyMs / 1000).toFixed(2)}s`);
-          }
+            if (isVerbose) {
+              console.log('  Timing breakdown:');
+              console.log(`    Total: ${(timing.totalMs / 1000).toFixed(2)}s`);
+              console.log(`    Issue upserts: ${(timing.upsertMs / 1000).toFixed(2)}s`);
+              console.log(`    Comment list: ${(timing.commentListMs / 1000).toFixed(2)}s`);
+              console.log(`    Comment upserts: ${(timing.commentUpsertMs / 1000).toFixed(2)}s`);
+              console.log(`    Hierarchy check: ${(timing.hierarchyCheckMs / 1000).toFixed(2)}s`);
+              console.log(`    Hierarchy link: ${(timing.hierarchyLinkMs / 1000).toFixed(2)}s`);
+              console.log(`    Hierarchy verify: ${(timing.hierarchyVerifyMs / 1000).toFixed(2)}s`);
+              // Display metric counts
+              const metrics = (timing as any).__metrics || {};
+              if (Object.keys(metrics).length > 0) {
+                console.log('  API call counts:');
+                for (const key of Object.keys(metrics)) {
+                  console.log(`    ${key}: ${metrics[key]}`);
+                }
+              }
+            }
         }
         logLine(`--- github push end ${new Date().toISOString()} ---`);
       } catch (error) {

--- a/src/github-metrics.ts
+++ b/src/github-metrics.ts
@@ -1,0 +1,33 @@
+/**
+ * Simple GitHub API metrics collector for per-run counters.
+ */
+
+const counters: Map<string, number> = new Map();
+
+export function increment(metric: string, n = 1): void {
+  const prev = counters.get(metric) || 0;
+  counters.set(metric, prev + n);
+  // Optional debug tracing to stderr so it doesn't pollute normal stdout output.
+  if (process.env.WL_GITHUB_TRACE === 'true') {
+    try { process.stderr.write(`[github-metrics] ${metric} += ${n}\n`); } catch (_) {}
+  }
+}
+
+export function snapshot(): Record<string, number> {
+  const out: Record<string, number> = {};
+  for (const [k, v] of counters.entries()) out[k] = v;
+  return out;
+}
+
+export function reset(): void {
+  counters.clear();
+}
+
+export function diff(before: Record<string, number>, after: Record<string, number>): Record<string, number> {
+  const keys = new Set<string>([...Object.keys(before), ...Object.keys(after)]);
+  const out: Record<string, number> = {};
+  for (const k of keys) {
+    out[k] = (after[k] || 0) - (before[k] || 0);
+  }
+  return out;
+}


### PR DESCRIPTION
Adds per-run API counters and wiring to GitHub push flow so \`wl github push --verbose\` logs per-phase timings and API call counts. Files: src/github-metrics.ts, src/github-sync.ts, src/commands/github.ts.

See work item WL-0MLCX6PP81TQ70AH for details.