### PR TITLE
WL-0MLOCF8110LGU0CG: defer git call in resolveWorklogDir

### DIFF
--- a/src/worklog-paths.ts
+++ b/src/worklog-paths.ts
@@ -4,11 +4,11 @@
 
 import * as fs from 'fs';
 import * as path from 'path';
-import { execSync } from 'child_process';
+import * as child_process from 'child_process';
 
 function getRepoRoot(): string | null {
   try {
-    const root = execSync('git rev-parse --show-toplevel', {
+    const root = child_process.execSync('git rev-parse --show-toplevel', {
       encoding: 'utf8',
       stdio: ['ignore', 'pipe', 'ignore']
     }).trim();
@@ -41,16 +41,27 @@ function hasWorklogConfig(worklogDir: string): boolean {
 export function resolveWorklogDir(): string {
   const cwd = process.cwd();
   const cwdWorklog = path.join(cwd, '.worklog');
-  const repoRoot = getRepoRoot();
-  const repoWorklog = repoRoot ? path.join(repoRoot, '.worklog') : null;
-  
-  // Check if .worklog exists in current directory
+
+  // If .worklog exists in the current directory prefer it and avoid
+  // invoking `git` unless we need to compare against the repo root.
   if (fs.existsSync(cwdWorklog)) {
+    // If this .worklog directory contains configuration/initialized marker
+    // we can safely return it without calling out to git.
+    if (hasWorklogConfig(cwdWorklog)) {
+      return cwdWorklog;
+    }
+
+    // Only now call git to inspect the repo root when the cwd .worklog
+    // exists but does not appear initialized — preserve previous behavior.
+    const repoRoot = getRepoRoot();
+    const repoWorklog = repoRoot ? path.join(repoRoot, '.worklog') : null;
+
     if (repoWorklog && repoWorklog !== cwdWorklog && fs.existsSync(repoWorklog)) {
       if (!hasWorklogConfig(cwdWorklog) && hasWorklogConfig(repoWorklog)) {
         return repoWorklog;
       }
     }
+
     return cwdWorklog;
   }
 
@@ -60,7 +71,11 @@ export function resolveWorklogDir(): string {
     return cwdWorklog;
   }
 
-  // Not in a worktree, so try to find .worklog in the repo root
+  // Not in a worktree, so try to find .worklog in the repo root — this
+  // requires calling git to find the repo top-level directory.
+  const repoRoot = getRepoRoot();
+  const repoWorklog = repoRoot ? path.join(repoRoot, '.worklog') : null;
+
   if (repoWorklog && repoRoot && repoRoot !== cwd) {
     if (fs.existsSync(repoWorklog)) {
       return repoWorklog;


### PR DESCRIPTION
Implemented deferred git invocation in resolveWorklogDir to avoid spawning git on hot path when .worklog exists in cwd. Tests: ran suite locally (394 tests passed). Commit: a9b9367.\n\nAcceptance: avoids subprocess when .worklog/initialized present; preserves fallback behavior when not initialized.