### PR TITLE
WL-0MKX63DHJ101712F: Refactor clipboard to async helper

### DIFF
--- a/src/clipboard.ts
+++ b/src/clipboard.ts
@@ -1,0 +1,46 @@
+import { spawn } from 'child_process';
+
+export type SpawnLike = (...args: any[]) => any;
+
+export async function copyToClipboard(text: string, opts?: { spawn?: SpawnLike }): Promise<{ success: boolean; error?: string }> {
+  const spawnImpl = opts?.spawn ?? spawn;
+
+  const run = (cmd: string, args: string[]) => new Promise<{ code: number | null; error?: Error }>((resolve) => {
+    try {
+      const cp = spawnImpl(cmd, args, { stdio: ['pipe', 'ignore', 'ignore'] });
+      let handled = false;
+      cp.on('error', (err: Error) => { if (!handled) { handled = true; resolve({ code: null, error: err }); } });
+      cp.on('close', (code: number) => { if (!handled) { handled = true; resolve({ code }); } });
+      try { cp.stdin.write(String(text)); cp.stdin.end(); } catch (_) {}
+    } catch (err: any) {
+      resolve({ code: null, error: err });
+    }
+  });
+
+  try {
+    const plat = process.platform;
+    if (plat === 'darwin') {
+      const res = await run('pbcopy', []);
+      if (res.code === 0) return { success: true };
+      return { success: false, error: res.error?.message || 'pbcopy failed' };
+    }
+
+    if (plat === 'win32') {
+      const res = await run('cmd', ['/c', 'clip']);
+      if (res.code === 0) return { success: true };
+      return { success: false, error: res.error?.message || 'clip failed' };
+    }
+
+    // Linux / other: try xclip then xsel
+    const xclip = await run('xclip', ['-selection', 'clipboard']);
+    if (xclip.code === 0) return { success: true };
+    const xsel = await run('xsel', ['--clipboard', '--input']);
+    if (xsel.code === 0) return { success: true };
+
+    // Prefer reporting command error messages if present
+    const errMsg = xclip.error?.message || xsel.error?.message || 'clipboard command not available (install xclip or xsel)';
+    return { success: false, error: errMsg };
+  } catch (err: any) {
+    return { success: false, error: err?.message || String(err) };
+  }
+}

--- a/src/tui/controller.ts
+++ b/src/tui/controller.ts
@@ -7,7 +7,8 @@ import type { PluginContext } from '../plugin-types.js';
 import type { WorkItem, WorkItemStatus } from '../types.js';
 import type { ChildProcess } from 'child_process';
 import blessed from 'blessed';
-import { spawn, spawnSync } from 'child_process';
+import { spawn } from 'child_process';
+import { copyToClipboard } from '../clipboard.js';
 import * as fs from 'fs';
 import * as path from 'path';
 import { humanFormatWorkItem, formatTitleOnlyTUI } from '../commands/helpers.js';
@@ -1927,38 +1928,17 @@ export class TuiController {
       return node?.item || null;
     }
 
-    function copyToClipboard(text: string): { success: boolean; error?: string } {
-      try {
-        if (process.platform === 'darwin') {
-          const result = spawnSync('pbcopy', [], { input: text, stdio: ['pipe', 'ignore', 'ignore'] });
-          if (result.status === 0) return { success: true };
-          return { success: false, error: result.error?.message || 'pbcopy failed' };
-        }
-
-        if (process.platform === 'win32') {
-          const result = spawnSync('cmd', ['/c', 'clip'], { input: text, stdio: ['pipe', 'ignore', 'ignore'] });
-          if (result.status === 0) return { success: true };
-          return { success: false, error: result.error?.message || 'clip failed' };
-        }
-
-        const xclip = spawnSync('xclip', ['-selection', 'clipboard'], { input: text, stdio: ['pipe', 'ignore', 'ignore'] });
-        if (xclip.status === 0) return { success: true };
-
-        const xsel = spawnSync('xsel', ['--clipboard', '--input'], { input: text, stdio: ['pipe', 'ignore', 'ignore'] });
-        if (xsel.status === 0) return { success: true };
-
-        return { success: false, error: xclip.error?.message || xsel.error?.message || 'clipboard command not available' };
-      } catch (err: any) {
-        return { success: false, error: err?.message || 'clipboard copy failed' };
-      }
-    }
-
-    function copySelectedId() {
+    async function copySelectedId() {
       const item = getSelectedItem();
       if (!item) return;
-      const result = copyToClipboard(item.id);
-      if (result.success) showToast('ID copied');
-      else showToast('Copy failed');
+      // use injected spawn implementation when available so tests can mock it
+      try {
+        const res = await copyToClipboard(item.id, { spawn: spawnImpl });
+        if (res.success) showToast('ID copied');
+        else showToast(res.error ? `Copy failed: ${res.error}` : 'Copy failed');
+      } catch (err: any) {
+        showToast(err?.message || 'Copy failed');
+      }
     }
 
     function closeSelectedItem(stage: 'in_review' | 'done' | 'deleted') {


### PR DESCRIPTION
This PR moves platform-specific clipboard logic out of the TUI controller into an async, testable helper . It replaces blocking  usage with an async  which accepts an injected  function for easier unit testing. Tests were run locally and all passed.\n\nChanges:\n- Add \n- Replace blocking clipboard logic in  with async helper\n\nWork item: WL-0MKX63DHJ101712F