### PR TITLE
WL-0MKYGWFDI19HQJC9: Extract TUI ID parsing utilities

### DIFF
--- a/src/tui/controller.ts
+++ b/src/tui/controller.ts
@@ -33,6 +33,7 @@ import {
 } from '../status-stage-rules.js';
 import { OpencodeClient, type OpencodeServerStatus } from './opencode-client.js';
 import ChordHandler from './chords.js';
+import { stripAnsi, stripTags, decorateIdsForClick, extractIdFromLine, extractIdAtColumn, stripTagsAndAnsiWithMap, wrapPlainLineWithMap } from './id-utils.js';
   import { AVAILABLE_COMMANDS, MIN_INPUT_HEIGHT, MAX_INPUT_LINES, FOOTER_HEIGHT, OPENCODE_SERVER_PORT,
   KEY_NAV_RIGHT, KEY_NAV_LEFT, KEY_TOGGLE_EXPAND, KEY_QUIT, KEY_ESCAPE, KEY_TOGGLE_HELP, KEY_CHORD_PREFIX, KEY_CHORD_FOLLOWUPS, KEY_OPEN_OPENCODE, KEY_OPEN_SEARCH,
   KEY_TAB, KEY_SHIFT_TAB, KEY_LEFT_SINGLE, KEY_RIGHT_SINGLE, KEY_CS, KEY_ENTER, KEY_LINEFEED, KEY_J, KEY_K, KEY_COPY_ID, KEY_PARENT_PREVIEW, KEY_CLOSE_ITEM, KEY_UPDATE_ITEM, KEY_REFRESH, KEY_FIND_NEXT, KEY_FILTER_IN_PROGRESS, KEY_FILTER_OPEN, KEY_FILTER_BLOCKED, KEY_MENU_CLOSE, KEY_TOGGLE_DO_NOT_DELEGATE } from './constants.js';
@@ -1488,36 +1489,7 @@ export class TuiController {
       detail.setScroll(0);
     }
 
-    function stripAnsi(value: string): string {
-      return value.replace(/\u001b\[[0-9;]*m/g, '');
-    }
-
-    function stripTags(value: string): string {
-      return value.replace(/{[^}]+}/g, '');
-    }
-
-    function decorateIdsForClick(value: string): string {
-      return value.replace(/\b[A-Z][A-Z0-9]+-[A-Z0-9-]+\b/g, '{underline}$&{/underline}');
-    }
-
-    function extractIdFromLine(line: string): string | null {
-      const plain = stripTags(stripAnsi(line));
-      const match = plain.match(/\b[A-Z][A-Z0-9]+-[A-Z0-9-]+\b/);
-      return match ? match[0] : null;
-    }
-
-    function extractIdAtColumn(line: string, col?: number): string | null {
-      const plain = stripTags(stripAnsi(line));
-      const matches = Array.from(plain.matchAll(/\b[A-Z][A-Z0-9]+-[A-Z0-9-]+\b/g));
-      if (matches.length === 0) return null;
-      if (typeof col !== 'number') return matches[0][0];
-      for (const match of matches) {
-        const start = match.index ?? 0;
-        const end = start + match[0].length;
-        if (col >= start && col <= end) return match[0];
-      }
-      return null;
-    }
+    // ID parsing utilities moved to src/tui/id-utils.ts
 
     function getClickRow(box: any, data: any): { row: number; col: number } | null {
       const lpos = box?.lpos;
@@ -1529,84 +1501,7 @@ export class TuiController {
       return { row, col };
     }
 
-    function stripTagsAndAnsiWithMap(value: string): { plain: string; map: number[] } {
-      let plain = '';
-      const map: number[] = [];
-      for (let i = 0; i < value.length; i += 1) {
-        const ch = value[i];
-        if (ch === '\u001b') {
-          let j = i + 1;
-          if (value[j] === '[') {
-            j += 1;
-            while (j < value.length && !/[A-Za-z]/.test(value[j])) j += 1;
-            if (j < value.length) j += 1;
-          }
-          i = j - 1;
-          continue;
-        }
-        if (ch === '{') {
-          const closeIdx = value.indexOf('}', i + 1);
-          if (closeIdx !== -1) {
-            i = closeIdx;
-            continue;
-          }
-        }
-        plain += ch;
-        map.push(i);
-      }
-      return { plain, map };
-    }
-
-    function wrapPlainLineWithMap(plain: string, map: number[], width: number): Array<{ plain: string; map: number[] }> {
-      if (width <= 0) return [{ plain, map }];
-      const words = plain.split(/\s+/).filter(Boolean);
-      if (words.length === 0) return [{ plain: '', map: [] }];
-      const chunks: Array<{ plain: string; map: number[] }> = [];
-      let current = '';
-      let currentMap: number[] = [];
-      let cursor = 0;
-      for (const word of words) {
-        const startIdx = plain.indexOf(word, cursor);
-        if (startIdx === -1) continue;
-        const wordMap = map.slice(startIdx, startIdx + word.length);
-        cursor = startIdx + word.length;
-        if (current.length === 0) {
-          if (word.length <= width) {
-            current = word;
-            currentMap = wordMap.slice();
-          } else {
-            for (let i = 0; i < word.length; i += width) {
-              const part = word.slice(i, i + width);
-              const partMap = wordMap.slice(i, i + width);
-              chunks.push({ plain: part, map: partMap });
-            }
-          }
-          continue;
-        }
-        if ((current.length + 1 + word.length) <= width) {
-          current += ` ${word}`;
-          currentMap = currentMap.concat(-1, ...wordMap);
-        } else {
-          chunks.push({ plain: current, map: currentMap });
-          if (word.length <= width) {
-            current = word;
-            currentMap = wordMap.slice();
-          } else {
-            for (let i = 0; i < word.length; i += width) {
-              const part = word.slice(i, i + width);
-              const partMap = wordMap.slice(i, i + width);
-              chunks.push({ plain: part, map: partMap });
-            }
-            current = '';
-            currentMap = [];
-          }
-        }
-      }
-      if (current.length > 0) {
-        chunks.push({ plain: current, map: currentMap });
-      }
-      return chunks;
-    }
+    // Use helpers from id-utils for mapping/line wrapping
 
     function getLineSegmentsForClick(box: any): Array<{ plain: string; map: number[] }> | null {
       if (!box?.lpos) return null;

--- a/src/tui/id-utils.ts
+++ b/src/tui/id-utils.ts
@@ -1,0 +1,113 @@
+// Utility helpers for parsing and decorating IDs in TUI output.
+// Extracted from src/tui/controller.ts to improve reuse and testability.
+export function stripAnsi(value: string): string {
+  return value.replace(/\u001b\[[0-9;]*m/g, '');
+}
+
+export function stripTags(value: string): string {
+  return value.replace(/{[^}]+}/g, '');
+}
+
+export function decorateIdsForClick(value: string): string {
+  return value.replace(/\b[A-Z][A-Z0-9]+-[A-Z0-9-]+\b/g, '{underline}$&{/underline}');
+}
+
+const ID_RE = /\b[A-Z][A-Z0-9]+-[A-Z0-9-]+\b/g;
+
+export function extractIdFromLine(line: string): string | null {
+  const plain = stripTags(stripAnsi(line));
+  const match = plain.match(/\b[A-Z][A-Z0-9]+-[A-Z0-9-]+\b/);
+  return match ? match[0] : null;
+}
+
+export function extractIdAtColumn(line: string, col?: number): string | null {
+  const plain = stripTags(stripAnsi(line));
+  const matches = Array.from(plain.matchAll(ID_RE));
+  if (matches.length === 0) return null;
+  if (typeof col !== 'number') return matches[0][0];
+  for (const match of matches) {
+    const start = match.index ?? 0;
+    const end = start + match[0].length;
+    if (col >= start && col <= end) return match[0];
+  }
+  return null;
+}
+
+export function stripTagsAndAnsiWithMap(value: string): { plain: string; map: number[] } {
+  let plain = '';
+  const map: number[] = [];
+  for (let i = 0; i < value.length; i += 1) {
+    const ch = value[i];
+    if (ch === '\u001b') {
+      let j = i + 1;
+      if (value[j] === '[') {
+        j += 1;
+        while (j < value.length && !/[A-Za-z]/.test(value[j])) j += 1;
+        if (j < value.length) j += 1;
+      }
+      i = j - 1;
+      continue;
+    }
+    if (ch === '{') {
+      const closeIdx = value.indexOf('}', i + 1);
+      if (closeIdx !== -1) {
+        i = closeIdx;
+        continue;
+      }
+    }
+    plain += ch;
+    map.push(i);
+  }
+  return { plain, map };
+}
+
+export function wrapPlainLineWithMap(plain: string, map: number[], width: number): Array<{ plain: string; map: number[] }> {
+  if (width <= 0) return [{ plain, map }];
+  const words = plain.split(/\s+/).filter(Boolean);
+  if (words.length === 0) return [{ plain: '', map: [] }];
+  const chunks: Array<{ plain: string; map: number[] }> = [];
+  let current = '';
+  let currentMap: number[] = [];
+  let cursor = 0;
+  for (const word of words) {
+    const startIdx = plain.indexOf(word, cursor);
+    if (startIdx === -1) continue;
+    const wordMap = map.slice(startIdx, startIdx + word.length);
+    cursor = startIdx + word.length;
+    if (current.length === 0) {
+      if (word.length <= width) {
+        current = word;
+        currentMap = wordMap.slice();
+      } else {
+        for (let i = 0; i < word.length; i += width) {
+          const part = word.slice(i, i + width);
+          const partMap = wordMap.slice(i, i + width);
+          chunks.push({ plain: part, map: partMap });
+        }
+      }
+      continue;
+    }
+    if ((current.length + 1 + word.length) <= width) {
+      current += ` ${word}`;
+      currentMap = currentMap.concat(-1, ...wordMap);
+    } else {
+      chunks.push({ plain: current, map: currentMap });
+      if (word.length <= width) {
+        current = word;
+        currentMap = wordMap.slice();
+      } else {
+        for (let i = 0; i < word.length; i += width) {
+          const part = word.slice(i, i + width);
+          const partMap = wordMap.slice(i, i + width);
+          chunks.push({ plain: part, map: partMap });
+        }
+        current = '';
+        currentMap = [];
+      }
+    }
+  }
+  if (current.length > 0) {
+    chunks.push({ plain: current, map: currentMap });
+  }
+  return chunks;
+}

--- a/test/tui/id-utils.test.ts
+++ b/test/tui/id-utils.test.ts
@@ -1,0 +1,62 @@
+import { describe, it, expect } from 'vitest';
+import {
+  stripAnsi,
+  stripTags,
+  decorateIdsForClick,
+  extractIdFromLine,
+  extractIdAtColumn,
+  stripTagsAndAnsiWithMap,
+  wrapPlainLineWithMap,
+} from '../../src/tui/id-utils.js';
+
+describe('id-utils', () => {
+  it('stripAnsi removes ANSI sequences', () => {
+    const v = 'foo\u001b[31mRED\u001b[0mbar';
+    expect(stripAnsi(v)).toBe('fooREDbar');
+  });
+
+  it('stripTags removes blessed-style tags', () => {
+    const v = 'a{red-fg}X{/red-fg}b';
+    expect(stripTags(v)).toBe('aXb');
+  });
+
+  it('decorateIdsForClick underlines IDs', () => {
+    const v = 'See WL-ABC123-1 in the log';
+    expect(decorateIdsForClick(v)).toContain('{underline}WL-ABC123-1{/underline}');
+  });
+
+  it('extractIdFromLine finds ID with ANSI/tags', () => {
+    const v = '\u001b[31m{bold}WL-FOO-1{/bold}\u001b[0m';
+    expect(extractIdFromLine(v)).toBe('WL-FOO-1');
+  });
+
+  it('extractIdAtColumn selects the id at a given column', () => {
+    const v = 'prefix WL-ONE-1 middle WL-TWO-2 suffix';
+    // ensure without column returns first
+    expect(extractIdAtColumn(v)).toBe('WL-ONE-1');
+    // compute index inside second id by finding plain index
+    const plain = v;
+    const i = plain.indexOf('WL-TWO-2');
+    expect(i).toBeGreaterThan(-1);
+    expect(extractIdAtColumn(v, i + 2)).toBe('WL-TWO-2');
+  });
+
+  it('stripTagsAndAnsiWithMap returns plain and map', () => {
+    const v = 'A\u001b[31mB\u001b[0mC{red}D{/red}E';
+    const out = stripTagsAndAnsiWithMap(v);
+    expect(out.plain).toBe('ABCDE');
+    expect(Array.isArray(out.map)).toBe(true);
+    expect(out.map.length).toBe(5);
+    for (const n of out.map) expect(typeof n).toBe('number');
+  });
+
+  it('wrapPlainLineWithMap returns single chunk when width large', () => {
+    const plain = 'hello world';
+    const map = Array.from(plain).map((_, i) => i);
+    const chunks = wrapPlainLineWithMap(plain, map, 50);
+    expect(chunks.length).toBe(1);
+    expect(chunks[0].plain).toBe(plain);
+    expect(Array.isArray(chunks[0].map)).toBe(true);
+    expect(chunks[0].map.length).toBe(plain.length);
+  });
+});


### PR DESCRIPTION
Refactor: move ID parsing/decoration helpers from src/tui/controller.ts to src/tui/id-utils.ts and add tests. Tests pass locally.\n\nChanges:\n- src/tui/id-utils.ts (new)\n- src/tui/controller.ts (imports updated)\n- test/tui/id-utils.test.ts (new)\n\nRationale: isolates text parsing logic for reuse and testability.\n\nTests: ran full test suite; all tests pass (401).