### PR TITLE
WL-0MLOWT9BG1J6K710: scope OpenCode server to TUI worklog

### DIFF
--- a/src/tui/controller.ts
+++ b/src/tui/controller.ts
@@ -147,6 +147,7 @@ export class TuiController {
 
     // Persisted state file per-worklog directory
     const worklogDir = resolveWorklogDirImpl();
+    const worklogRoot = pathImpl.dirname(worklogDir);
     const statePath = pathImpl.join(worklogDir, 'tui-state.json');
     void statePath;
 
@@ -1224,6 +1225,7 @@ export class TuiController {
 
     const opencodeClient = new OpencodeClientImpl({
       port: OPENCODE_SERVER_PORT,
+      cwd: worklogRoot,
       log: debugLog,
       showToast,
       modalDialogs,

--- a/src/tui/opencode-client.ts
+++ b/src/tui/opencode-client.ts
@@ -78,6 +78,7 @@ export interface SendPromptOptions {
 
 export interface OpencodeClientOptions {
   port: number;
+  cwd?: string;
   log: (message: string) => void;
   showToast: (message: string) => void;
   modalDialogs: ModalDialogsApi;
@@ -115,28 +116,65 @@ export class OpencodeClient {
   }
 
   async startServer(): Promise<boolean> {
-    const isRunning = await this.checkOpencodeServer(this.options.port);
-    if (isRunning) {
-      this.setStatus('running', this.options.port);
-      return true;
+    const configuredPort = this.options.port;
+    if (configuredPort > 0) {
+      const isRunning = await this.checkOpencodeServer(configuredPort);
+      if (isRunning) {
+        this.setStatus('running', configuredPort);
+        return true;
+      }
+    } else if (this.opencodeServerPort > 0) {
+      const isRunning = await this.checkOpencodeServer(this.opencodeServerPort);
+      if (isRunning) {
+        this.setStatus('running', this.opencodeServerPort);
+        return true;
+      }
     }
-
-    this.setStatus('starting', this.options.port);
+    this.setStatus('starting', configuredPort);
     this.options.showToast('Starting OpenCode server...');
 
+    let detectedPort = 0;
     try {
-      this.options.log(`starting opencode server port=${this.options.port}`);
-      this.opencodeServerProc = this.spawnImpl('opencode', ['serve', '--port', String(this.options.port)], {
+      this.options.log(`starting opencode server port=${configuredPort} cwd=${this.options.cwd ?? process.cwd()}`);
+      const opencodeEnv = {
+        ...process.env,
+        WORKLOG_DIR: this.options.cwd ? `${this.options.cwd}/.worklog` : process.env.WORKLOG_DIR,
+      };
+      const args = ['serve'];
+      const portArg = configuredPort > 0 ? configuredPort : this.opencodeServerPort;
+      if (portArg && portArg > 0) {
+        args.push('--port', String(portArg));
+      }
+      this.opencodeServerProc = this.spawnImpl('opencode', args, {
         stdio: ['ignore', 'pipe', 'pipe'],
         detached: false,
+        env: opencodeEnv,
+        ...(this.options.cwd ? { cwd: this.options.cwd } : {}),
       });
 
       // Attach listeners but avoid re-attaching if they already exist (in
       // case startServer is retried). Use named functions so we can remove
       // them reliably in stopServer.
-      const handleStdout = (chunk: any) => { this.options.log(`server stdout: ${chunk.toString().trim()}`); };
+      const handleStdout = (chunk: any) => {
+        const line = chunk.toString().trim();
+        this.options.log(`server stdout: ${line}`);
+        const match = line.match(/listening on http:\/\/[^:]+:(\d+)/i);
+        if (match && match[1]) {
+          const parsed = Number(match[1]);
+          if (!Number.isNaN(parsed) && parsed > 0 && detectedPort !== parsed) {
+            detectedPort = parsed;
+            this.opencodeServerPort = parsed;
+            this.options.log(`detected opencode server port=${parsed}`);
+          }
+        }
+      };
       const handleStderr = (chunk: any) => { this.options.log(`server stderr: ${chunk.toString().trim()}`); };
       const handleExit = (code: any, signal: any) => { this.options.log(`server exit code=${code ?? 'null'} signal=${signal ?? 'null'}`); };
+      const handleError = (err: any) => {
+        this.options.log(`server spawn error: ${String(err)}`);
+        this.setStatus('error', this.options.port);
+        this.options.showToast(`OpenCode server spawn error: ${String(err)}`);
+      };
 
       if (this.opencodeServerProc.stdout && !(this.opencodeServerProc.stdout as any).__opencode_listeners_installed) {
         this.opencodeServerProc.stdout.on('data', handleStdout);
@@ -150,22 +188,47 @@ export class OpencodeClient {
         this.opencodeServerProc.on('exit', handleExit);
         (this.opencodeServerProc as any).__opencode_exit_listener_installed = true;
       }
+      if (!(this.opencodeServerProc as any).__opencode_error_listener_installed) {
+        this.opencodeServerProc.on('error', handleError);
+        (this.opencodeServerProc as any).__opencode_error_listener_installed = true;
+      }
 
-      this.opencodeServerPort = this.options.port;
+      this.opencodeServerPort = configuredPort;
+      this.options.log(`opencode server spawned pid=${this.opencodeServerProc.pid ?? 'unknown'} port=${configuredPort}`);
 
-      let retries = 10;
+      let retries = 40;
       while (retries > 0) {
         await new Promise(resolve => setTimeout(resolve, 500));
-        const isUp = await this.checkOpencodeServer(this.options.port);
-        if (isUp) {
-          this.setStatus('running', this.options.port);
-          this.options.showToast('OpenCode server started');
-          return true;
+        if (configuredPort > 0) {
+          const isUp = await this.checkOpencodeServer(configuredPort);
+          if (isUp) {
+            this.setStatus('running', configuredPort);
+            this.options.showToast('OpenCode server started');
+            return true;
+          }
+        } else {
+          if (detectedPort === 0) {
+            this.options.log('waiting for opencode port detection...');
+            retries--;
+            continue;
+          }
+          const isUp = await this.checkOpencodeServer(detectedPort);
+          if (isUp) {
+            this.setStatus('running', detectedPort);
+            this.options.showToast('OpenCode server started');
+            return true;
+          }
         }
         retries--;
       }
 
-      this.setStatus('error', this.options.port);
+      if (configuredPort === 0 && detectedPort === 0 && this.opencodeServerProc) {
+        this.setStatus('starting', 0);
+        this.options.showToast('OpenCode server still starting');
+        return false;
+      }
+
+      this.setStatus('error', detectedPort || configuredPort);
       this.options.showToast('OpenCode server failed to start');
       if (this.opencodeServerProc) {
         // Ensure we remove any listeners before killing the child process so
@@ -179,7 +242,7 @@ export class OpencodeClient {
       }
       return false;
     } catch (err) {
-      this.setStatus('error', this.options.port);
+      this.setStatus('error', detectedPort || configuredPort);
       this.options.showToast(`Failed to start OpenCode server: ${String(err)}`);
       return false;
     }
@@ -434,10 +497,12 @@ export class OpencodeClient {
   private setStatus(status: OpencodeServerStatus, port: number): void {
     this.opencodeServerStatus = status;
     this.opencodeServerPort = port;
+    this.options.log(`server status=${status} port=${port}`);
     if (this.options.onStatusChange) {
       this.options.onStatusChange(status, port);
     }
   }
+
 
   private resolveSessionSelection(preferredSessionId: string | null): Promise<SessionSelectionResult> {
     const sessionFromMemory = this.getSessionFromCurrent(preferredSessionId);
@@ -473,8 +538,8 @@ export class OpencodeClient {
         resolve(false);
       });
 
-      req.on('error', () => {
-        this.options.log('health check error');
+      req.on('error', (err) => {
+        this.options.log(`health check error: ${String(err)}`);
         resolve(false);
       });
 
@@ -538,6 +603,14 @@ export class OpencodeClient {
         const data = JSON.parse(payload);
         const dataType = data?.type || 'unknown';
         this.options.log(`sse data type=${dataType}`);
+        if (dataType === 'session.updated' && data?.properties?.info) {
+          const info = data.properties.info;
+          const dir = info.directory || info.cwd || info.workdir || info.path;
+          const projectId = info.projectID || info.projectId;
+          if (dir || projectId) {
+            this.options.log(`session info dir=${dir ?? 'unknown'} project=${projectId ?? 'unknown'}`);
+          }
+        }
 
         this.handleSseEvent({
           data,

--- a/tests/tui/opencode-child-lifecycle.test.ts
+++ b/tests/tui/opencode-child-lifecycle.test.ts
@@ -5,9 +5,11 @@ describe('OpencodeClient child process lifecycle', () => {
   it('removes listeners and kills child on stopServer and allows restart without leaking', async () => {
     let spawnCount = 0;
     const procs: any[] = [];
+    let lastSpawnOpts: any = null;
 
     const spawnImpl = (_name: string, _args: string[], _opts: any) => {
       spawnCount++;
+      lastSpawnOpts = _opts;
       const stdoutListeners: string[] = [];
       const stderrListeners: string[] = [];
       const proc: any = {
@@ -31,6 +33,7 @@ describe('OpencodeClient child process lifecycle', () => {
 
     const client = new OpencodeClient({
       port: 4321,
+      cwd: '/tmp/worklog-root',
       log: () => {},
       showToast: () => {},
       modalDialogs: { selectList: async () => null, editTextarea: async () => null, confirmTextbox: async () => true },
@@ -51,6 +54,7 @@ describe('OpencodeClient child process lifecycle', () => {
     expect(started).toBe(true);
     expect(spawnCount).toBe(1);
     expect(procs.length).toBe(1);
+    expect(lastSpawnOpts?.cwd).toBe('/tmp/worklog-root');
 
     // stop the server — should call kill and remove listeners
     client.stopServer();

--- a/tests/tui/opencode-triple-keypress.repro.test.ts
+++ b/tests/tui/opencode-triple-keypress.repro.test.ts
@@ -1,0 +1,50 @@
+import { describe, it, expect, vi } from 'vitest';
+import { TuiController } from '../../src/tui/controller.js';
+
+// Minimal repro test that demonstrates each keypress inserting three
+// characters after reopening the opencode overlay.
+it('reproduces triple keypress after reopen', async () => {
+  const makeBox = () => ({ hidden: true, show: vi.fn(), hide: vi.fn(), focus: vi.fn(), setValue: vi.fn(), getValue: vi.fn(() => ''), on: vi.fn(), key: vi.fn(), setScrollPerc: vi.fn(), setContent: vi.fn(), setItems: vi.fn(), select: vi.fn(), getItem: vi.fn(() => ({ getContent: vi.fn(() => '') })) });
+  const makeTextarea = () => ({ value: '', setValue: vi.fn((v: string) => { (textarea as any).value = v; }), getValue: vi.fn(() => (textarea as any).value), clearValue: vi.fn(), on: vi.fn(), screen: null });
+  // Use existing test helpers minimal mocks from other tests
+  const screen = { height: 40, width: 120, focused: null, program: { y: 0, x: 0, cuf: vi.fn(), cub: vi.fn(), cud: vi.fn(), cuu: vi.fn(), cup: vi.fn() }, render: vi.fn(), destroy: vi.fn(), key: vi.fn(), on: vi.fn() } as any;
+
+  const overlays = { detailOverlay: makeBox(), closeOverlay: makeBox(), updateOverlay: makeBox() } as any;
+  const dialogs = { detailModal: makeBox(), detailClose: makeBox(), closeDialog: makeBox(), closeDialogText: makeBox(), closeDialogOptions: makeBox(), updateDialog: makeBox(), updateDialogText: makeBox(), updateDialogOptions: makeBox(), updateDialogStageOptions: makeBox(), updateDialogStatusOptions: makeBox(), updateDialogPriorityOptions: makeBox(), updateDialogComment: makeBox() } as any;
+
+  const opencodeText = makeTextarea();
+  const opencodeUi = { serverStatusBox: makeBox(), dialog: makeBox(), textarea: opencodeText, suggestionHint: makeBox(), sendButton: makeBox(), cancelButton: makeBox(), ensureResponsePane: vi.fn(() => makeBox()) } as any;
+
+  const makeDetailBox = () => ({ ...makeBox(), setScroll: vi.fn(), screen, setLine: vi.fn(), setLabel: vi.fn() });
+  const layout = { screen, listComponent: { getList: () => makeBox(), getFooter: () => makeBox() }, detailComponent: { getDetail: () => makeDetailBox(), getCopyIdButton: () => makeBox() }, toastComponent: { show: vi.fn() }, overlaysComponent: overlays, dialogsComponent: dialogs, helpMenu: { isVisible: vi.fn(() => false), show: vi.fn(), hide: vi.fn() }, modalDialogs: { selectList: vi.fn(async () => null), editTextarea: vi.fn(async () => null), confirmTextbox: vi.fn(async () => true), forceCleanup: vi.fn() }, opencodeUi, nextDialog: { overlay: makeBox(), dialog: makeBox(), close: makeBox(), text: makeBox(), options: makeBox() } } as any;
+
+  const ctx = { program: { opts: () => ({ verbose: false }) }, utils: { requireInitialized: vi.fn(), getDatabase: vi.fn(() => ({ list: () => ([{ id: 'WL-TEST-1', title: 'Test item', status: 'open', priority: 'low', sortIndex: 1, parentId: null, createdAt: '', updatedAt: '', tags: [], assignee: '', stage: '', issueType: 'task', createdBy: '', deletedBy: '', deleteReason: '', risk: '', effort: '' } as any]), getPrefix: () => undefined, getCommentsForWorkItem: () => [], update: () => ({}), createComment: () => ({}), get: () => null })) } } as any;
+
+  class FakeOpencodeClient { getStatus() { return { status: 'stopped', port: 9999 }; } startServer() { return Promise.resolve(true); } stopServer() { return undefined; } sendPrompt() { return Promise.resolve(); } }
+
+  const controller = new TuiController(ctx, { createLayout: () => layout as any, OpencodeClient: FakeOpencodeClient as any, resolveWorklogDir: () => '/tmp', createPersistence: () => ({ loadPersistedState: async () => null, savePersistedState: async () => undefined, statePath: '/tmp/tui-state.json' }) });
+
+  // Start controller to wire handlers
+  await controller.start({});
+
+  // Simulate open -> type -> close -> reopen -> type -> expect single char insertion
+  const textarea = opencodeText as any;
+  textarea.screen = screen;
+  textarea.value = '';
+  // Ensure listeners exist
+  const inputHandler = textarea._listener || textarea.__opencode_keypress || null;
+  expect(inputHandler).not.toBeNull();
+
+  // Initial open: type 'x' twice
+  inputHandler.call(textarea, 'x', { name: 'x' });
+  expect(textarea.getValue()).toContain('x');
+
+  // Simulate close (controller keeps dialog open but clears value)
+  if (typeof textarea.clearValue === 'function') textarea.clearValue();
+  textarea.value = '';
+
+  // Reopen and type a single char - regression shows 3 chars
+  inputHandler.call(textarea, 'y', { name: 'y' });
+  // We expect only one char inserted
+  expect(textarea.getValue().length).toBe(1);
+});


### PR DESCRIPTION
## Summary
- spawn the OpenCode server with the TUI worklog root as `cwd` and `WORKLOG_DIR`
- improve server startup handling by detecting the listening port from stdout and logging status changes
- add/extend TUI tests to cover opencode spawn options and repro harness

## Testing
- npm test -- --run tests/tui/opencode-child-lifecycle.test.ts
- npm test -- --run tests/tui/opencode-triple-keypress.repro.test.ts

## Review Focus
- confirm opencode server uses the TUI project's worklog and reports the correct port
- sanity-check the startup retry/port detection flow