### PR TITLE
WL-0MLGTWT4S1X4HDD9: default needs-producer-review list filter

### DIFF
--- a/CLI.md
+++ b/CLI.md
@@ -238,6 +238,7 @@ Options:
 `-a, --assignee <assignee>` (optional)
 `-n, --number <n>` (optional) — Limit the number of items returned
 `--stage <stage>` (optional)
+`--needs-producer-review [value]` (optional; defaults to `true` when omitted; accepts true|false|yes|no)
 `--prefix <prefix>` (optional)
 `--json` (optional)
 
@@ -249,6 +250,7 @@ wl list -s open -p high
 wl list "signup"
 wl -F concise list -s in-progress
 wl --json list -s open --tags backlog
+wl list --needs-producer-review
 ```
 
 ---

--- a/src/cli-types.ts
+++ b/src/cli-types.ts
@@ -42,7 +42,7 @@ export interface ListOptions {
   assignee?: string;
   stage?: string;
   /** 'true'|'false'|'yes'|'no' (string form from CLI); parsed to boolean by command */
-  needsProducerReview?: string;
+  needsProducerReview?: string | boolean;
   prefix?: string;
   number?: string;
 }

--- a/src/commands/create.ts
+++ b/src/commands/create.ts
@@ -30,7 +30,7 @@ export default function register(ctx: PluginContext): void {
     .option('--created-by <createdBy>', 'Created by (interoperability field)')
     .option('--deleted-by <deletedBy>', 'Deleted by (interoperability field)')
     .option('--delete-reason <deleteReason>', 'Delete reason (interoperability field)')
-    .option('--needs-producer-review <true|false>', 'Set needsProducerReview flag for the new item')
+    .option('--needs-producer-review <true|false>', 'Set needsProducerReview flag for the new item (true|false|yes|no)')
     .option('--prefix <prefix>', 'Override the default prefix')
     .action(async (options: CreateOptions) => {
       utils.requireInitialized();

--- a/src/commands/list.ts
+++ b/src/commands/list.ts
@@ -22,7 +22,7 @@ export default function register(ctx: PluginContext): void {
     .option('--tags <tags>', 'Filter by tags (comma-separated)')
     .option('-a, --assignee <assignee>', 'Filter by assignee')
     .option('--stage <stage>', 'Filter by stage')
-    .option('--needs-producer-review <true|false>', 'Filter by needsProducerReview flag (true|false)')
+    .option('--needs-producer-review [value]', 'Filter by needsProducerReview flag (true|false|yes|no; default true when omitted)')
     .option('--prefix <prefix>', 'Override the default prefix')
     .action((search: string | undefined, options: ListOptions) => {
       utils.requireInitialized();
@@ -47,15 +47,19 @@ export default function register(ctx: PluginContext): void {
       if (options.assignee) query.assignee = options.assignee;
       if (options.stage) query.stage = options.stage;
       if (options.needsProducerReview !== undefined) {
-        // Accept common boolean-like CLI values
-        const raw = String(options.needsProducerReview).toLowerCase();
-        const truthy = ['true', 'yes', '1'];
-        const falsy = ['false', 'no', '0'];
-        if (truthy.includes(raw)) query.needsProducerReview = true;
-        else if (falsy.includes(raw)) query.needsProducerReview = false;
-        else {
-          output.error(`Invalid value for --needs-producer-review: ${options.needsProducerReview}`, { success: false, error: 'invalid-arg' });
-          process.exit(1);
+        if (options.needsProducerReview === true) {
+          query.needsProducerReview = true;
+        } else {
+          // Accept common boolean-like CLI values
+          const raw = String(options.needsProducerReview).toLowerCase();
+          const truthy = ['true', 'yes', '1', ''];
+          const falsy = ['false', 'no', '0'];
+          if (truthy.includes(raw)) query.needsProducerReview = true;
+          else if (falsy.includes(raw)) query.needsProducerReview = false;
+          else {
+            output.error(`Invalid value for --needs-producer-review: ${options.needsProducerReview}`, { success: false, error: 'invalid-arg' });
+            process.exit(1);
+          }
         }
       }
       

--- a/src/database.ts
+++ b/src/database.ts
@@ -372,7 +372,7 @@ export class WorklogDatabase {
       githubIssueId: undefined,
       githubIssueUpdatedAt: undefined,
       // default for the new flag
-      needsProducerReview: false,
+      needsProducerReview: input.needsProducerReview ?? false,
     };
 
     this.store.saveWorkItem(item);

--- a/tests/cli/cli-helpers.ts
+++ b/tests/cli/cli-helpers.ts
@@ -206,6 +206,7 @@ export function seedWorkItems(
     tags?: string[];
     assignee?: string;
     stage?: string;
+    needsProducerReview?: boolean;
   }>,
   comments: Comment[] = []
 ): WorkItem[] {
@@ -229,6 +230,7 @@ export function seedWorkItems(
     deleteReason: '',
     risk: '' as const,
     effort: '' as const,
+    needsProducerReview: item.needsProducerReview ?? false,
   }));
 
   const dataPath = path.join(dir, '.worklog', 'worklog-data.jsonl');

--- a/tests/cli/issue-status.test.ts
+++ b/tests/cli/issue-status.test.ts
@@ -25,9 +25,9 @@ describe('CLI Issue Status Tests', () => {
   describe('list command', () => {
     beforeEach(() => {
       seedWorkItems(tempState.tempDir, [
-        { title: 'Task 1', status: 'open', priority: 'high' },
+        { title: 'Task 1', status: 'open', priority: 'high', needsProducerReview: true },
         { title: 'Task 2', status: 'in-progress', priority: 'medium' },
-        { title: 'Task 3', status: 'completed', priority: 'low' },
+        { title: 'Task 3', status: 'completed', priority: 'low', needsProducerReview: true },
       ]);
     });
 
@@ -100,6 +100,33 @@ describe('CLI Issue Status Tests', () => {
       expect(listedIds).toContain(child2Id);
       expect(listedIds).not.toContain(parent.id);
       expect(listedIds).not.toContain(unrelatedId);
+    });
+
+    it('should filter by needs-producer-review true', async () => {
+      const { stdout } = await execAsync(`tsx ${cliPath} --json list --needs-producer-review true`);
+
+      const result = JSON.parse(stdout);
+      expect(result.success).toBe(true);
+      expect(result.workItems).toHaveLength(2);
+      result.workItems.forEach((item: any) => expect(item.needsProducerReview).toBe(true));
+    });
+
+    it('should default needs-producer-review to true when value omitted', async () => {
+      const { stdout } = await execAsync(`tsx ${cliPath} --json list --needs-producer-review`);
+
+      const result = JSON.parse(stdout);
+      expect(result.success).toBe(true);
+      expect(result.workItems).toHaveLength(2);
+      result.workItems.forEach((item: any) => expect(item.needsProducerReview).toBe(true));
+    });
+
+    it('should filter by needs-producer-review false', async () => {
+      const { stdout } = await execAsync(`tsx ${cliPath} --json list --needs-producer-review false`);
+
+      const result = JSON.parse(stdout);
+      expect(result.success).toBe(true);
+      expect(result.workItems).toHaveLength(1);
+      result.workItems.forEach((item: any) => expect(item.needsProducerReview).not.toBe(true));
     });
 
     it('should error for invalid parent id', async () => {

--- a/tests/database.test.ts
+++ b/tests/database.test.ts
@@ -119,10 +119,10 @@ describe('WorklogDatabase', () => {
   describe('list', () => {
     beforeEach(() => {
       // Create test data
-      db.create({ title: 'Task 1', status: 'open', priority: 'high' });
+      db.create({ title: 'Task 1', status: 'open', priority: 'high', needsProducerReview: true });
       db.create({ title: 'Task 2', status: 'in-progress', priority: 'medium' });
       db.create({ title: 'Task 3', status: 'completed', priority: 'low' });
-      db.create({ title: 'Task 4', status: 'open', priority: 'high', tags: ['backend'] });
+      db.create({ title: 'Task 4', status: 'open', priority: 'high', tags: ['backend'], needsProducerReview: true });
       db.create({ title: 'Task 5', status: 'blocked', priority: 'critical', assignee: 'alice' });
     });
 
@@ -167,6 +167,18 @@ describe('WorklogDatabase', () => {
     it('should filter by parentId null (root items)', () => {
       const items = db.list({ parentId: null });
       expect(items).toHaveLength(5);
+    });
+
+    it('should filter by needsProducerReview true', () => {
+      const items = db.list({ needsProducerReview: true });
+      expect(items).toHaveLength(2);
+      items.forEach(item => expect(item.needsProducerReview).toBe(true));
+    });
+
+    it('should filter by needsProducerReview false', () => {
+      const items = db.list({ needsProducerReview: false });
+      expect(items).toHaveLength(3);
+      items.forEach(item => expect(item.needsProducerReview).not.toBe(true));
     });
   });
 


### PR DESCRIPTION
## Summary
- default `wl list --needs-producer-review` to true when value omitted
- accept boolean-like values and update CLI docs for the new option
- add database + CLI tests for needsProducerReview filtering

## Testing
- npm test -- tests/database.test.ts tests/cli/issue-status.test.ts

## Review focus
- list option parsing/default behavior and CLI docs
- needsProducerReview handling in `WorklogDatabase.create()` and list filtering

Refs: WL-0MLGTWT4S1X4HDD9