### PR TITLE
WL-0MKXK36KJ1L2ADCN: improve OpenCode progress feedback

### DIFF
--- a/TUI.md
+++ b/TUI.md
@@ -54,7 +54,7 @@ The OpenCode server automatically starts when you press O. Server status indicat
 
 - `[-]` — Server stopped
 - `[~]` — Server starting
-- `[OK] Port: 9999` — Server running (default; configurable via `OPENCODE_SERVER_PORT`)
+- `[OK] Port: 9999` — Server running (example; configurable via `OPENCODE_SERVER_PORT` or auto-selected)
 - `[X]` — Server error
 
 ### Slash Commands

--- a/docs/opencode-tui.md
+++ b/docs/opencode-tui.md
@@ -19,7 +19,7 @@ The Worklog TUI now includes full integration with OpenCode, an AI-powered codin
   - `[~]` - Server starting
   - `[OK] Port: 51625` - Server running
   - `[X]` - Server error
-- Default port: 9999 (configurable via `OPENCODE_SERVER_PORT` environment variable)
+- Default port: Let OpenCode choose (override with `OPENCODE_SERVER_PORT`)
 
 ### 3. Slash Command Autocomplete
 
@@ -118,7 +118,7 @@ Focus on performance and readability.
 
 ### Environment Variables
 
-- `OPENCODE_SERVER_PORT` - Override the default server port (9999)
+- `OPENCODE_SERVER_PORT` - Override the server port (if unset, OpenCode chooses)
 
 Note: Worklog’s OpenCode client does not currently attach auth headers, so enabling OpenCode server auth will likely prevent the TUI from connecting.
 

--- a/src/tui/constants.ts
+++ b/src/tui/constants.ts
@@ -158,8 +158,9 @@ export const MIN_INPUT_HEIGHT = 3; // Minimum height for input dialog (single li
 export const MAX_INPUT_LINES = 7;  // Maximum visible lines of input text
 export const FOOTER_HEIGHT = 1;    // Height reserved for the footer
 
-// Default port for the OpenCode server; honoring OPENCODE_SERVER_PORT env var.
-export const OPENCODE_SERVER_PORT = parseInt(process.env.OPENCODE_SERVER_PORT || '9999', 10);
+// Port for the OpenCode server; if unset, let the server select its own port.
+const parsedOpencodePort = Number.parseInt(process.env.OPENCODE_SERVER_PORT ?? '', 10);
+export const OPENCODE_SERVER_PORT = Number.isFinite(parsedOpencodePort) ? parsedOpencodePort : 0;
 
 export default {
   AVAILABLE_COMMANDS,

--- a/src/tui/controller.ts
+++ b/src/tui/controller.ts
@@ -715,6 +715,9 @@ export class TuiController {
     let isCommandMode = false;
     let userTypedText = '';
     let isWaitingForResponse = false; // Track if we're waiting for OpenCode response
+    const promptSpinnerFrames = ['⠋', '⠙', '⠹', '⠸', '⠼', '⠴', '⠦', '⠧', '⠇', '⠏'];
+    let promptSpinnerIndex = 0;
+    let promptSpinnerTimer: ReturnType<typeof setInterval> | null = null;
 
     type OpencodeInputMode = 'insert' | 'normal';
     let opencodeInputMode: OpencodeInputMode = 'insert';
@@ -738,8 +741,31 @@ export class TuiController {
 
     const updateOpencodePromptLabel = (state: 'idle' | 'waiting') => {
       const modeSuffix = opencodeInputMode === 'normal' ? ' [normal]' : '';
-      const stateSuffix = state === 'waiting' ? ' (waiting...)' : '';
+      let stateSuffix = '';
+      if (state === 'waiting') {
+        const spinner = promptSpinnerFrames[promptSpinnerIndex % promptSpinnerFrames.length] || promptSpinnerFrames[0];
+        stateSuffix = ` (waiting ${spinner})`;
+      }
       opencodeDialog.setLabel(` prompt${stateSuffix} [esc]${modeSuffix} `);
+    };
+
+    const startPromptSpinner = () => {
+      if (promptSpinnerTimer) return;
+      promptSpinnerIndex = 0;
+      promptSpinnerTimer = setInterval(() => {
+        if (!isWaitingForResponse) return;
+        promptSpinnerIndex = (promptSpinnerIndex + 1) % promptSpinnerFrames.length;
+        updateOpencodePromptLabel('waiting');
+        screen.render();
+      }, 120);
+    };
+
+    const stopPromptSpinner = () => {
+      if (promptSpinnerTimer) {
+        clearInterval(promptSpinnerTimer);
+        promptSpinnerTimer = null;
+      }
+      promptSpinnerIndex = 0;
     };
 
     const getLineColumnFromIndex = (value: string, index: number) => {
@@ -1303,6 +1329,7 @@ export class TuiController {
 
       // Set flag to block new requests and update label
       isWaitingForResponse = true;
+      startPromptSpinner();
       updateOpencodePromptLabel('waiting');
       screen.render();
 
@@ -1317,6 +1344,7 @@ export class TuiController {
           onComplete: () => {
           // Clear flag when response completes and restore label
           isWaitingForResponse = false;
+          stopPromptSpinner();
           updateOpencodePromptLabel('idle');
           openOpencodeDialog();
           },
@@ -1324,6 +1352,7 @@ export class TuiController {
       } catch (err) {
         // Clear flag on error too and restore label
         isWaitingForResponse = false;
+        stopPromptSpinner();
         updateOpencodePromptLabel('idle');
         opencodePane.pushLine(`{red-fg}Server communication error: ${err}{/red-fg}`);
         screen.render();

--- a/src/tui/opencode-client.ts
+++ b/src/tui/opencode-client.ts
@@ -559,7 +559,11 @@ export class OpencodeClient {
   ) {
     let resRef: any = null;
     let req: any = null;
+    let sessionEnded = false;
     const onSessionEnd = () => {
+      if (sessionEnded) return;
+      sessionEnded = true;
+      sseClosed = true;
       try { req?.abort?.(); } catch (_) {}
       try { resRef?.removeAllListeners?.(); } catch (_) {}
       try { req?.removeAllListeners?.(); } catch (_) {}
@@ -1054,6 +1058,10 @@ export class OpencodeClient {
           setLastUserMessageId(messageId);
         }
         this.options.log(`sse message updated role=${messageRole} id=${messageId}`);
+        const completed = info?.time?.completed;
+        if (messageRole === 'assistant' && completed) {
+          handlers.onSessionEnd();
+        }
       }
       return;
     }

--- a/tests/tui/controller.test.ts
+++ b/tests/tui/controller.test.ts
@@ -193,6 +193,6 @@ describe('TuiController', () => {
 
     expect(createLayout).toHaveBeenCalled();
     expect(opencodeCtorCalls.length).toBe(1);
-    expect(opencodeCtorCalls[0].port).toBe(9999);
+    expect(opencodeCtorCalls[0].port).toBe(0);
   });
 });

--- a/tests/tui/opencode-activity.test.ts
+++ b/tests/tui/opencode-activity.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { OpencodeClient } from '../../src/tui/opencode-client.js';
+import { TuiController } from '../../src/tui/controller.js';
 
 describe('OpencodeClient activity indicators', () => {
   const makeClient = () => new OpencodeClient({
@@ -83,5 +84,225 @@ describe('OpencodeClient activity indicators', () => {
     const calls = (pane.setLabel as any).mock.calls;
     const lastLabel = calls[calls.length - 1][0] as string;
     expect(lastLabel).toContain('opencode');
+  });
+});
+
+describe('OpenCode prompt spinner', () => {
+  const makeBox = () => ({
+    hidden: true,
+    width: 0,
+    height: 0,
+    style: { border: {}, label: {}, selected: {} },
+    show: vi.fn(function() { (this as any).hidden = false; }),
+    hide: vi.fn(function() { (this as any).hidden = true; }),
+    focus: vi.fn(),
+    setFront: vi.fn(),
+    setContent: vi.fn(),
+    getContent: vi.fn(() => ''),
+    setLabel: vi.fn(),
+    setItems: vi.fn(),
+    select: vi.fn(),
+    getItem: vi.fn(() => undefined),
+    on: vi.fn(),
+    key: vi.fn(),
+    setScroll: vi.fn(),
+    setScrollPerc: vi.fn(),
+    getScroll: vi.fn(() => 0),
+    pushLine: vi.fn(),
+    clearValue: vi.fn(),
+    setValue: vi.fn(),
+    getValue: vi.fn(() => ''),
+    moveCursor: vi.fn(),
+    _updateCursor: vi.fn(),
+  });
+
+  const makeList = () => {
+    const list = makeBox() as any;
+    let selected = 0;
+    let items: string[] = [];
+    list.setItems = vi.fn((next: string[]) => {
+      items = next.slice();
+      list.items = items.map(value => ({ getContent: () => value }));
+    });
+    list.select = vi.fn((idx: number) => { selected = idx; });
+    Object.defineProperty(list, 'selected', {
+      get: () => selected,
+      set: (value: number) => { selected = value; },
+    });
+    list.getItem = vi.fn((idx: number) => {
+      const value = items[idx];
+      return value ? { getContent: () => value } : undefined;
+    });
+    list.items = [] as any[];
+    return list;
+  };
+
+  const makeTextarea = () => {
+    const box = makeBox() as any;
+    box.value = '';
+    box.setValue = vi.fn((value: string) => { box.value = value; });
+    box.getValue = vi.fn(() => box.value);
+    box.clearValue = vi.fn(() => { box.value = ''; });
+    return box;
+  };
+
+  const makeScreen = () => ({
+    height: 40,
+    width: 120,
+    focused: null,
+    program: { y: 0, x: 0, cuf: vi.fn(), cub: vi.fn(), cud: vi.fn(), cuu: vi.fn(), cup: vi.fn() },
+    render: vi.fn(),
+    destroy: vi.fn(),
+    key: vi.fn(),
+    on: vi.fn(),
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('animates spinner while waiting and stops on completion', async () => {
+    vi.useFakeTimers();
+    const screen = makeScreen();
+    const list = makeList();
+    const footer = makeBox();
+    const detail = makeBox();
+    const copyIdButton = makeBox();
+    const overlays = {
+      detailOverlay: makeBox(),
+      closeOverlay: makeBox(),
+      updateOverlay: makeBox(),
+    };
+    const dialogs = {
+      detailModal: makeBox(),
+      detailClose: makeBox(),
+      closeDialog: makeBox(),
+      closeDialogText: makeBox(),
+      closeDialogOptions: makeList(),
+      updateDialog: makeBox(),
+      updateDialogText: makeBox(),
+      updateDialogOptions: makeList(),
+      updateDialogStageOptions: makeList(),
+      updateDialogStatusOptions: makeList(),
+      updateDialogPriorityOptions: makeList(),
+      updateDialogComment: makeTextarea(),
+    };
+    const helpMenu = {
+      isVisible: vi.fn(() => false),
+      show: vi.fn(),
+      hide: vi.fn(),
+    };
+    const modalDialogs = {
+      selectList: vi.fn(async () => null),
+      editTextarea: vi.fn(async () => null),
+      confirmTextbox: vi.fn(async () => true),
+      forceCleanup: vi.fn(),
+    };
+    const opencodeText = makeTextarea();
+    const opencodeDialog = makeBox();
+    const responsePane = makeBox();
+    const opencodeUi = {
+      serverStatusBox: makeBox(),
+      dialog: opencodeDialog,
+      textarea: opencodeText,
+      suggestionHint: makeBox(),
+      sendButton: makeBox(),
+      cancelButton: makeBox(),
+      ensureResponsePane: vi.fn(() => responsePane),
+    };
+    const layout = {
+      screen,
+      listComponent: { getList: () => list, getFooter: () => footer },
+      detailComponent: { getDetail: () => detail, getCopyIdButton: () => copyIdButton },
+      toastComponent: { show: vi.fn() } as any,
+      overlaysComponent: overlays,
+      dialogsComponent: dialogs,
+      helpMenu,
+      modalDialogs,
+      opencodeUi,
+      nextDialog: {
+        overlay: makeBox(),
+        dialog: makeBox(),
+        close: makeBox(),
+        text: makeBox(),
+        options: makeList(),
+      },
+    };
+
+    const ctx = {
+      program: { opts: () => ({ verbose: false }) },
+      utils: {
+        requireInitialized: vi.fn(),
+        getDatabase: vi.fn(() => ({
+          list: () => [
+            {
+              id: 'WL-TEST-1',
+              title: 'Test',
+              description: '',
+              status: 'open',
+              priority: 'medium',
+              sortIndex: 0,
+              parentId: null,
+              createdAt: new Date().toISOString(),
+              updatedAt: new Date().toISOString(),
+              tags: [],
+              assignee: '',
+              stage: '',
+              issueType: 'task',
+              createdBy: '',
+              deletedBy: '',
+              deleteReason: '',
+              risk: '',
+              effort: '',
+            },
+          ],
+          getPrefix: () => undefined,
+          getCommentsForWorkItem: () => [],
+          update: () => ({}),
+          createComment: () => ({}),
+          get: () => null,
+        })),
+      },
+    } as any;
+
+    let onComplete: (() => void) | undefined;
+    class FakeOpencodeClient {
+      getStatus() { return { status: 'running', port: 9999 }; }
+      startServer() { return Promise.resolve(true); }
+      stopServer() { return undefined; }
+      sendPrompt(options: any) { onComplete = options.onComplete; return Promise.resolve(); }
+    }
+
+    const controller = new TuiController(ctx, {
+      createLayout: () => layout as any,
+      OpencodeClient: FakeOpencodeClient as any,
+      resolveWorklogDir: () => '/tmp',
+      createPersistence: () => ({
+        loadPersistedState: async () => null,
+        savePersistedState: async () => undefined,
+        statePath: '/tmp/tui-state.json',
+      }),
+    });
+
+    await controller.start({});
+
+    opencodeText.setValue('hello');
+    const sendHandler = (opencodeUi.sendButton as any).__opencode_click as (() => void) | undefined;
+    expect(typeof sendHandler).toBe('function');
+    sendHandler?.();
+
+    expect(opencodeDialog.setLabel).toHaveBeenCalled();
+    const initialLabel = (opencodeDialog.setLabel as any).mock.calls.slice(-1)[0][0] as string;
+    expect(initialLabel).toContain('waiting');
+
+    vi.advanceTimersByTime(240);
+    const calls = (opencodeDialog.setLabel as any).mock.calls;
+    const lastLabel = calls[calls.length - 1][0] as string;
+    expect(lastLabel).toContain('waiting');
+
+    onComplete?.();
+    vi.advanceTimersByTime(200);
+    const finalLabel = (opencodeDialog.setLabel as any).mock.calls.slice(-1)[0][0] as string;
+    expect(finalLabel).not.toContain('waiting');
   });
 });


### PR DESCRIPTION
## Summary
- add animated waiting spinner in the OpenCode prompt label and clear it on completion/error
- allow OpenCode server to auto-select its port when OPENCODE_SERVER_PORT is unset
- update docs/tests for the new port behavior and spinner flow

## Testing
- npm test

## Review Focus
- prompt label spinner behavior in OpenCode flow
- port selection changes when OPENCODE_SERVER_PORT is unset
- SSE completion handling for progress cleanup

Refs: WL-0MKXK36KJ1L2ADCN