### PR TITLE
WL-0MKYX0V5M13IC9XZ: Integrated shell for TUI prompt

### DIFF
--- a/TUI.md
+++ b/TUI.md
@@ -41,6 +41,9 @@ This document describes the interactive terminal UI shipped as the `wl tui` (or 
   - Ctrl+S — send prompt
   - Enter — accept autocomplete or add newline
   - Escape — close dialog
+  - Prefix `!` to run a local shell command in the project root
+  - Ctrl+C cancels a running `!` command without closing the prompt
+  - Command shows in orange; output streams in white
 - When OpenCode is active:
   - Response appears in bottom pane
   - Input fields appear when agent needs information

--- a/docs/opencode-tui.md
+++ b/docs/opencode-tui.md
@@ -57,7 +57,14 @@ The Worklog TUI now includes full integration with OpenCode, an AI-powered codin
 - User responses are shown in cyan in the conversation
 - Press Escape to cancel input mode
 
-### 7. Prompt Input Auto-Resize
+### 7. Integrated Shell Commands
+
+- Prefix a prompt with `!` to run a local shell command in the project root
+- Output streams directly into the response pane as raw stdout/stderr
+- The command displays in orange and output in white
+- Press `Ctrl+C` while the prompt is focused to cancel a running shell command
+
+### 8. Prompt Input Auto-Resize
 
 - The prompt input box grows as long lines wrap within the terminal
 - Auto-resize caps at a maximum height; beyond that, the input scrolls
@@ -79,6 +86,7 @@ The Worklog TUI now includes full integration with OpenCode, an AI-powered codin
    - `Ctrl+S` - Send prompt
    - `Enter` - Accept autocomplete or add newline
    - `Escape` - Close dialog
+   - `Ctrl+C` - Cancel running `!` command
 
 - **In the response pane:**
   - Arrow keys or vim keys (`j`/`k`) - Scroll through response
@@ -228,3 +236,8 @@ Planned improvements include:
 ---
 
 For more information about OpenCode, visit: https://opencode.ai/docs/
+#### Running a Shell Command
+
+```
+!ls
+```

--- a/src/theme.ts
+++ b/src/theme.ts
@@ -36,6 +36,8 @@ export const theme = {
       success: tuiWrap('green-fg'),
       warning: tuiWrap('yellow-fg'),
       error: tuiWrap('red-fg'),
+      shellCommand: tuiWrap('214-fg'),
+      shellOutput: tuiWrap('white-fg'),
     },
     status: {
       open: tuiWrap('green-fg'),

--- a/src/tui/components/opencode-pane.ts
+++ b/src/tui/components/opencode-pane.ts
@@ -140,6 +140,7 @@ export class OpencodePaneComponent {
       label: options.label,
       border: { type: 'line' },
       tags: true,
+      parseTags: true,
       scrollable: true,
       alwaysScroll: true,
       keys: true,

--- a/src/tui/constants.ts
+++ b/src/tui/constants.ts
@@ -106,7 +106,7 @@ export const DEFAULT_SHORTCUTS = [
   {
     category: 'Exit',
     items: [
-      { keys: 'q, Esc, Ctrl-C', description: 'Quit' },
+      { keys: 'q, Esc, Ctrl-C', description: 'Quit (Ctrl-C in prompt cancels shell)' },
     ],
   },
 ];

--- a/src/tui/controller.ts
+++ b/src/tui/controller.ts
@@ -716,6 +716,9 @@ export class TuiController {
     let isCommandMode = false;
     let userTypedText = '';
     let isWaitingForResponse = false; // Track if we're waiting for OpenCode response
+    let isLocalShellRunning = false;
+    let localShellProcess: ChildProcess | null = null;
+    let localShellOutput = '';
     const promptSpinnerFrames = ['⠋', '⠙', '⠹', '⠸', '⠼', '⠴', '⠦', '⠧', '⠇', '⠏'];
     let promptSpinnerIndex = 0;
     let promptSpinnerTimer: ReturnType<typeof setInterval> | null = null;
@@ -734,10 +737,12 @@ export class TuiController {
       (opencodeText as any).__opencode_cursor = opencodeCursorIndex;
     };
 
+    const isPromptBusy = () => isWaitingForResponse || isLocalShellRunning;
+
     const setOpencodeInputMode = (mode: OpencodeInputMode) => {
       opencodeInputMode = mode;
       (opencodeText as any).__opencode_mode = opencodeInputMode;
-      updateOpencodePromptLabel(isWaitingForResponse ? 'waiting' : 'idle');
+      updateOpencodePromptLabel(isPromptBusy() ? 'waiting' : 'idle');
     };
 
     const updateOpencodePromptLabel = (state: 'idle' | 'waiting') => {
@@ -754,7 +759,7 @@ export class TuiController {
       if (promptSpinnerTimer) return;
       promptSpinnerIndex = 0;
       promptSpinnerTimer = setInterval(() => {
-        if (!isWaitingForResponse) return;
+        if (!isPromptBusy()) return;
         promptSpinnerIndex = (promptSpinnerIndex + 1) % promptSpinnerFrames.length;
         updateOpencodePromptLabel('waiting');
         screen.render();
@@ -1276,7 +1281,7 @@ export class TuiController {
     const initialStatus = opencodeClient.getStatus();
     updateServerStatus(initialStatus.status, initialStatus.port);
     
-    function ensureOpencodePane() {
+    function ensureOpencodePane(label = ' opencode [esc] ') {
       // In compact mode, adjust pane position to be above the input
       const currentHeight = opencodeDialog.height || MIN_INPUT_HEIGHT;
       const bottomOffset = currentHeight + FOOTER_HEIGHT;
@@ -1284,8 +1289,8 @@ export class TuiController {
       opencodePane = opencodeUi.ensureResponsePane({
         bottom: bottomOffset,
         height: paneHeight(),
-        label: ' opencode [esc] ',
-      onEscape: () => {
+        label,
+        onEscape: () => {
           // Suppress the global escape handler immediately so the
           // response-pane-local Escape doesn't also trigger the
           // global handler (which would close the input dialog).
@@ -1298,14 +1303,97 @@ export class TuiController {
       });
     }
 
+    const appendLocalShellOutput = (chunk: string) => {
+      localShellOutput += theme.tui.text.shellOutput(escapeBlessedTags(chunk));
+      if (opencodePane?.setContent) {
+        opencodePane.setContent(localShellOutput);
+      }
+      if (opencodePane?.setScrollPerc) {
+        opencodePane.setScrollPerc(100);
+      }
+      screen.render();
+    };
+
+    const stopLocalShell = () => {
+      isLocalShellRunning = false;
+      localShellProcess = null;
+      stopPromptSpinner();
+      updateOpencodePromptLabel('idle');
+    };
+
+    const cancelLocalShell = () => {
+      if (!localShellProcess) return;
+      try { localShellProcess.kill('SIGINT'); } catch (_) {}
+    };
+
+    const runLocalShellCommand = (prompt: string) => {
+      if (isPromptBusy()) {
+        showToast('Please wait for current response to complete');
+        return;
+      }
+
+      const command = prompt.slice(1);
+      if (command.trim() === '') {
+        showToast('Empty command');
+        return;
+      }
+
+      ensureOpencodePane(' shell [esc] ');
+      opencodePane.show();
+      opencodePane.setFront();
+      screen.render();
+
+      localShellOutput = `${theme.tui.text.shellCommand(`$ ${escapeBlessedTags(command)}`)}\n`;
+      if (opencodePane?.setContent) opencodePane.setContent(localShellOutput);
+      if (opencodePane?.setScrollPerc) opencodePane.setScrollPerc(100);
+
+      isLocalShellRunning = true;
+      startPromptSpinner();
+      updateOpencodePromptLabel('waiting');
+      screen.render();
+
+      try {
+        localShellProcess = spawnImpl(command, {
+          cwd: worklogRoot,
+          shell: process.env.SHELL || true,
+          env: process.env,
+          stdio: ['ignore', 'pipe', 'pipe'],
+        });
+      } catch (err) {
+        stopLocalShell();
+        showToast(`Command failed to start: ${String(err)}`);
+        return;
+      }
+
+      localShellProcess.stdout?.on('data', (chunk: Buffer) => {
+        appendLocalShellOutput(chunk.toString());
+      });
+      localShellProcess.stderr?.on('data', (chunk: Buffer) => {
+        appendLocalShellOutput(chunk.toString());
+      });
+      localShellProcess.on('error', (err: unknown) => {
+        stopLocalShell();
+        showToast(`Command failed: ${String(err)}`);
+      });
+      localShellProcess.on('close', () => {
+        stopLocalShell();
+        try { openOpencodeDialog(); } catch (_) {}
+      });
+    };
+
     async function runOpencode(prompt: string) {
       if (!prompt || prompt.trim() === '') {
         showToast('Empty prompt');
         return;
       }
 
+      if (prompt.startsWith('!')) {
+        runLocalShellCommand(prompt);
+        return;
+      }
+
       // Block if we're already waiting for a response
-      if (isWaitingForResponse) {
+      if (isPromptBusy()) {
         showToast('Please wait for current response to complete');
         return;
       }
@@ -1374,6 +1462,14 @@ export class TuiController {
       screen.render();
     };
     try { (opencodeText as any).__opencode_key_escape = opencodeTextEscapeHandler; opencodeText.key(KEY_ESCAPE, opencodeTextEscapeHandler); } catch (_) {}
+
+    const opencodeTextCtrlCHandler = function(this: any) {
+      if (isLocalShellRunning) {
+        cancelLocalShell();
+        return;
+      }
+    };
+    try { (opencodeText as any).__opencode_key_cc = opencodeTextCtrlCHandler; opencodeText.key(['C-c'], opencodeTextCtrlCHandler); } catch (_) {}
 
     // Accept Ctrl+S to send (keep for backward compatibility)
     const opencodeTextCSHandler = function(this: any) {
@@ -2449,6 +2545,10 @@ export class TuiController {
     // Quit keys: q and Ctrl-C always quit; Escape should close the help overlay
     // when it's open instead of exiting the whole TUI.
     screen.key(KEY_QUIT, () => {
+      if (isLocalShellRunning) {
+        cancelLocalShell();
+        return;
+      }
       shutdown();
     });
 

--- a/src/tui/layout.ts
+++ b/src/tui/layout.ts
@@ -85,6 +85,14 @@ export function createLayout(options: CreateLayoutOptions = {}): TuiLayout {
     ...options.screenOptions,
   });
 
+  // Force 256-color support so blessed tags like {214-fg} render correctly.
+  // Blessed relies on terminfo (tput) which may report only 8 colors even
+  // when the terminal actually supports 256.  Modern terminals universally
+  // handle 256-color SGR sequences, so this override is safe.
+  if (screen.program?.tput && screen.program.tput.colors < 256) {
+    screen.program.tput.colors = 256;
+  }
+
   // ── List (left pane + footer) ───────────────────────────────────────
   const listComponent = new ListComponent({
     parent: screen,


### PR DESCRIPTION
## Summary

- Adds local shell execution to the TUI OpenCode prompt: prefix any prompt with `!` to run it as a shell command in the project root
- stdout/stderr stream into the response pane in real time; the command line displays in orange (256-color 214) and output in white
- Ctrl+C cancels a running shell command without closing the prompt or exiting the TUI

## Changes

| File | What changed |
|------|-------------|
| `src/tui/controller.ts` | Shell execution logic, streaming output, Ctrl+C handler, `isPromptBusy()` guard |
| `src/tui/layout.ts` | Force `tput.colors = 256` so blessed renders 256-color tags correctly |
| `src/theme.ts` | `shellCommand` (`{214-fg}` orange) and `shellOutput` (`{white-fg}`) theme entries |
| `src/tui/components/opencode-pane.ts` | Enable `parseTags` on the response pane |
| `src/tui/constants.ts` | Updated help text for Ctrl+C behavior |
| `TUI.md` | Documented shell command feature |
| `docs/opencode-tui.md` | Documented shell command feature with usage example |

## Testing

All 416 passing tests continue to pass. The 2 pre-existing timeout failures in `tests/cli/worktree.test.ts` are unrelated.

## Work Item

Closes WL-0MKYX0V5M13IC9XZ (Integrated Shell)