### PR TITLE
WL-0MLB80G0L1AR9HP0: Add TUI integration tests for persistence, focus cycling, and layout

### DIFF
--- a/tests/tui/focus-cycling-integration.test.ts
+++ b/tests/tui/focus-cycling-integration.test.ts
@@ -1,0 +1,546 @@
+/**
+ * Integration tests for TUI focus cycling with Ctrl-W chord sequences.
+ * Validates that focus moves between panes correctly and that key events
+ * do not leak to widget-level handlers after chord consumption.
+ *
+ * Related work item: WL-0MLR6RTM11N96HX5
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { TuiController } from '../../src/tui/controller.js';
+
+// ── Blessed mock helpers ──────────────────────────────────────────────
+
+const makeBox = () => ({
+  hidden: true,
+  width: 0,
+  height: 0,
+  style: { border: {} as Record<string, any>, label: {} as Record<string, any>, selected: {} },
+  show: vi.fn(function () { (this as any).hidden = false; }),
+  hide: vi.fn(function () { (this as any).hidden = true; }),
+  focus: vi.fn(),
+  setFront: vi.fn(),
+  setContent: vi.fn(),
+  getContent: vi.fn(() => ''),
+  setLabel: vi.fn(),
+  setItems: vi.fn(),
+  select: vi.fn(),
+  getItem: vi.fn(() => undefined),
+  on: vi.fn(),
+  key: vi.fn(),
+  setScroll: vi.fn(),
+  setScrollPerc: vi.fn(),
+  getScroll: vi.fn(() => 0),
+  pushLine: vi.fn(),
+  clearValue: vi.fn(),
+  setValue: vi.fn(),
+  getValue: vi.fn(() => ''),
+  moveCursor: vi.fn(),
+});
+
+const makeList = () => {
+  const list = makeBox() as any;
+  let selected = 0;
+  let items: string[] = [];
+  list.setItems = vi.fn((next: string[]) => {
+    items = next.slice();
+    list.items = items.map(value => ({ getContent: () => value }));
+  });
+  list.select = vi.fn((idx: number) => { selected = idx; });
+  Object.defineProperty(list, 'selected', {
+    get: () => selected,
+    set: (value: number) => { selected = value; },
+  });
+  list.getItem = vi.fn((idx: number) => {
+    const value = items[idx];
+    return value ? { getContent: () => value } : undefined;
+  });
+  list.items = [] as any[];
+  return list;
+};
+
+const makeScreen = () => ({
+  height: 40,
+  width: 120,
+  focused: null as any,
+  render: vi.fn(),
+  destroy: vi.fn(),
+  key: vi.fn(),
+  on: vi.fn(),
+});
+
+// ── Factory for test items ────────────────────────────────────────────
+
+function makeItem(id: string, parentId: string | null = null) {
+  const now = new Date().toISOString();
+  return {
+    id,
+    title: `Item ${id}`,
+    description: '',
+    status: 'open',
+    priority: 'medium',
+    sortIndex: 0,
+    parentId,
+    createdAt: now,
+    updatedAt: now,
+    tags: [],
+    assignee: '',
+    stage: '',
+    issueType: 'task',
+    createdBy: '',
+    deletedBy: '',
+    deleteReason: '',
+    risk: '',
+    effort: '',
+    needsProducerReview: false,
+  };
+}
+
+// ── Helpers ───────────────────────────────────────────────────────────
+
+function buildLayout(screen: any) {
+  const list = makeList();
+  const footer = makeBox();
+  const detail = makeBox();
+  const copyIdButton = makeBox();
+  const overlays = {
+    detailOverlay: makeBox(),
+    closeOverlay: makeBox(),
+    updateOverlay: makeBox(),
+  };
+  const dialogs = {
+    detailModal: makeBox(),
+    detailClose: makeBox(),
+    closeDialog: makeBox(),
+    closeDialogText: makeBox(),
+    closeDialogOptions: makeList(),
+    updateDialog: makeBox(),
+    updateDialogText: makeBox(),
+    updateDialogOptions: makeList(),
+    updateDialogStageOptions: makeList(),
+    updateDialogStatusOptions: makeList(),
+    updateDialogPriorityOptions: makeList(),
+    updateDialogComment: makeBox(),
+  };
+  const helpMenu = {
+    isVisible: vi.fn(() => false),
+    show: vi.fn(),
+    hide: vi.fn(),
+  };
+  const modalDialogs = {
+    selectList: vi.fn(async () => 0),
+    editTextarea: vi.fn(async () => null),
+    confirmTextbox: vi.fn(async () => false),
+    forceCleanup: vi.fn(),
+  };
+  const opencodeUi = {
+    serverStatusBox: makeBox(),
+    dialog: makeBox(),
+    textarea: makeBox(),
+    suggestionHint: makeBox(),
+    sendButton: makeBox(),
+    cancelButton: makeBox(),
+    ensureResponsePane: vi.fn(() => makeBox()),
+  };
+
+  return {
+    screen,
+    list,
+    detail,
+    opencodeDialog: opencodeUi.dialog,
+    opencodeText: opencodeUi.textarea,
+    layout: {
+      screen,
+      listComponent: { getList: () => list, getFooter: () => footer },
+      detailComponent: { getDetail: () => detail, getCopyIdButton: () => copyIdButton },
+      toastComponent: { show: vi.fn() } as any,
+      overlaysComponent: overlays,
+      dialogsComponent: dialogs,
+      helpMenu,
+      modalDialogs,
+      opencodeUi,
+      nextDialog: {
+        overlay: makeBox(),
+        dialog: makeBox(),
+        close: makeBox(),
+        text: makeBox(),
+        options: makeList(),
+      },
+    },
+  };
+}
+
+function buildCtx(items: any[]) {
+  return {
+    program: { opts: () => ({ verbose: false }) },
+    utils: {
+      requireInitialized: vi.fn(),
+      getDatabase: vi.fn(() => ({
+        list: () => items,
+        getPrefix: () => 'test-prefix',
+        getCommentsForWorkItem: () => [],
+        update: () => ({}),
+        createComment: () => ({}),
+        get: (id: string) => items.find(i => i.id === id) ?? null,
+      })),
+    },
+  } as any;
+}
+
+class FakeOpencodeClient {
+  getStatus() { return { status: 'stopped', port: 9999 }; }
+  startServer() { return Promise.resolve(true); }
+  stopServer() { return undefined; }
+  sendPrompt() { return Promise.resolve(); }
+}
+
+/**
+ * Extracts registered key handlers from a mock's call history.
+ *
+ * screen.key(keys, handler) is captured by vi.fn().
+ * screen.on('keypress', handler) is captured similarly.
+ */
+function getKeyHandler(mockFn: ReturnType<typeof vi.fn>, keyOrEvent: string | string[]): ((...args: any[]) => any) | null {
+  const calls = mockFn.mock.calls;
+  for (const call of calls) {
+    const registeredKeys = call[0];
+    const handler = call[1];
+    if (typeof registeredKeys === 'string') {
+      if (registeredKeys === keyOrEvent) return handler;
+    }
+    if (Array.isArray(registeredKeys) && Array.isArray(keyOrEvent)) {
+      // Check if the registered keys include any of the requested keys
+      if (keyOrEvent.some(k => registeredKeys.includes(k))) return handler;
+    }
+    if (Array.isArray(registeredKeys) && typeof keyOrEvent === 'string') {
+      if (registeredKeys.includes(keyOrEvent)) return handler;
+    }
+  }
+  return null;
+}
+
+function getEventHandler(mockFn: ReturnType<typeof vi.fn>, event: string): ((...args: any[]) => any) | null {
+  const calls = mockFn.mock.calls;
+  for (const call of calls) {
+    if (call[0] === event) return call[1];
+  }
+  return null;
+}
+
+/**
+ * Simulates a Ctrl-W chord sequence by invoking both the raw keypress
+ * handler and the screen.key wrapper, matching how blessed dispatches events.
+ */
+function simulateCtrlWChord(
+  screen: any,
+  followupKey: string,
+) {
+  const keypressHandler = getEventHandler(screen.on, 'keypress');
+  const ctrlWKeyHandler = getKeyHandler(screen.key, ['C-w']);
+  const followupKeyHandler = getKeyHandler(screen.key, ['h', 'j', 'k', 'l', 'w', 'p']);
+
+  // Step 1: send Ctrl-W leader key
+  const ctrlWKey = { name: 'w', ctrl: true };
+  if (keypressHandler) keypressHandler('', ctrlWKey);
+  if (ctrlWKeyHandler) ctrlWKeyHandler('', ctrlWKey);
+
+  // Step 2: send the follow-up key
+  const followKey = { name: followupKey };
+  if (keypressHandler) keypressHandler(followupKey, followKey);
+  if (followupKeyHandler) followupKeyHandler(followupKey, followKey);
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────
+
+describe('TUI focus cycling integration', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('registers Ctrl-W chord handlers on startup', async () => {
+    const root = makeItem('WL-FOCUS-1');
+    const screen = makeScreen();
+    const { layout } = buildLayout(screen);
+    const ctx = buildCtx([root]);
+
+    const controller = new TuiController(ctx, {
+      createLayout: () => layout as any,
+      OpencodeClient: FakeOpencodeClient as any,
+      resolveWorklogDir: () => '/tmp/test-worklog',
+      createPersistence: () => ({
+        loadPersistedState: async () => null,
+        savePersistedState: async () => undefined,
+        statePath: '/tmp/tui-state.json',
+      }),
+    });
+
+    await controller.start({});
+
+    // Check that screen.key was called with C-w prefix
+    const keyCalls = (screen.key as ReturnType<typeof vi.fn>).mock.calls;
+    const hasCtrlW = keyCalls.some((call: any[]) => {
+      const keys = Array.isArray(call[0]) ? call[0] : [call[0]];
+      return keys.includes('C-w');
+    });
+    expect(hasCtrlW).toBe(true);
+
+    // Check that screen.on was called with 'keypress'
+    const onCalls = (screen.on as ReturnType<typeof vi.fn>).mock.calls;
+    const hasKeypress = onCalls.some((call: any[]) => call[0] === 'keypress');
+    expect(hasKeypress).toBe(true);
+  });
+
+  it('sets focus styles on the list pane at startup', async () => {
+    const root = makeItem('WL-FOCUS-1');
+    const screen = makeScreen();
+    const { layout, list } = buildLayout(screen);
+    const ctx = buildCtx([root]);
+
+    const controller = new TuiController(ctx, {
+      createLayout: () => layout as any,
+      OpencodeClient: FakeOpencodeClient as any,
+      resolveWorklogDir: () => '/tmp/test-worklog',
+      createPersistence: () => ({
+        loadPersistedState: async () => null,
+        savePersistedState: async () => undefined,
+        statePath: '/tmp/tui-state.json',
+      }),
+    });
+
+    await controller.start({});
+
+    // List should have green border (focused)
+    expect(list.style.border.fg).toBe('green');
+  });
+
+  it('Ctrl-W w cycles focus forward', async () => {
+    const root = makeItem('WL-FOCUS-1');
+    const screen = makeScreen();
+    const { layout, list, detail } = buildLayout(screen);
+    const ctx = buildCtx([root]);
+
+    const controller = new TuiController(ctx, {
+      createLayout: () => layout as any,
+      OpencodeClient: FakeOpencodeClient as any,
+      resolveWorklogDir: () => '/tmp/test-worklog',
+      createPersistence: () => ({
+        loadPersistedState: async () => null,
+        savePersistedState: async () => undefined,
+        statePath: '/tmp/tui-state.json',
+      }),
+    });
+
+    await controller.start({});
+
+    // Initial focus should be on list
+    expect(list.style.border.fg).toBe('green');
+
+    // Simulate Ctrl-W w to cycle focus
+    simulateCtrlWChord(screen, 'w');
+
+    // Detail should now be focused (green border)
+    expect(detail.style.border.fg).toBe('green');
+    // List should be unfocused (white border)
+    expect(list.style.border.fg).toBe('white');
+  });
+
+  it('Ctrl-W h moves focus left', async () => {
+    const root = makeItem('WL-FOCUS-1');
+    const screen = makeScreen();
+    const { layout, list, detail } = buildLayout(screen);
+    const ctx = buildCtx([root]);
+
+    const controller = new TuiController(ctx, {
+      createLayout: () => layout as any,
+      OpencodeClient: FakeOpencodeClient as any,
+      resolveWorklogDir: () => '/tmp/test-worklog',
+      createPersistence: () => ({
+        loadPersistedState: async () => null,
+        savePersistedState: async () => undefined,
+        statePath: '/tmp/tui-state.json',
+      }),
+    });
+
+    await controller.start({});
+
+    // First cycle to detail (Ctrl-W w)
+    simulateCtrlWChord(screen, 'w');
+    expect(detail.style.border.fg).toBe('green');
+
+    // Now Ctrl-W h should move back to list
+    simulateCtrlWChord(screen, 'h');
+    expect(list.style.border.fg).toBe('green');
+    expect(detail.style.border.fg).toBe('white');
+  });
+
+  it('Ctrl-W l moves focus right', async () => {
+    const root = makeItem('WL-FOCUS-1');
+    const screen = makeScreen();
+    const { layout, list, detail } = buildLayout(screen);
+    const ctx = buildCtx([root]);
+
+    const controller = new TuiController(ctx, {
+      createLayout: () => layout as any,
+      OpencodeClient: FakeOpencodeClient as any,
+      resolveWorklogDir: () => '/tmp/test-worklog',
+      createPersistence: () => ({
+        loadPersistedState: async () => null,
+        savePersistedState: async () => undefined,
+        statePath: '/tmp/tui-state.json',
+      }),
+    });
+
+    await controller.start({});
+
+    // List is focused initially; Ctrl-W l should move to detail
+    simulateCtrlWChord(screen, 'l');
+    expect(detail.style.border.fg).toBe('green');
+    expect(list.style.border.fg).toBe('white');
+  });
+
+  it('Ctrl-W p returns to previous pane', async () => {
+    const root = makeItem('WL-FOCUS-1');
+    const screen = makeScreen();
+    const { layout, list, detail } = buildLayout(screen);
+    const ctx = buildCtx([root]);
+
+    const controller = new TuiController(ctx, {
+      createLayout: () => layout as any,
+      OpencodeClient: FakeOpencodeClient as any,
+      resolveWorklogDir: () => '/tmp/test-worklog',
+      createPersistence: () => ({
+        loadPersistedState: async () => null,
+        savePersistedState: async () => undefined,
+        statePath: '/tmp/tui-state.json',
+      }),
+    });
+
+    await controller.start({});
+
+    // Move to detail
+    simulateCtrlWChord(screen, 'w');
+    expect(detail.style.border.fg).toBe('green');
+
+    // Ctrl-W p should go back to list (previous pane)
+    simulateCtrlWChord(screen, 'p');
+    expect(list.style.border.fg).toBe('green');
+    expect(detail.style.border.fg).toBe('white');
+  });
+
+  it('chord events do not leak when help menu is visible', async () => {
+    const root = makeItem('WL-FOCUS-1');
+    const screen = makeScreen();
+    const { layout, list, detail } = buildLayout(screen);
+    const ctx = buildCtx([root]);
+
+    // Make help menu visible
+    (layout.helpMenu.isVisible as ReturnType<typeof vi.fn>).mockReturnValue(true);
+
+    const controller = new TuiController(ctx, {
+      createLayout: () => layout as any,
+      OpencodeClient: FakeOpencodeClient as any,
+      resolveWorklogDir: () => '/tmp/test-worklog',
+      createPersistence: () => ({
+        loadPersistedState: async () => null,
+        savePersistedState: async () => undefined,
+        statePath: '/tmp/tui-state.json',
+      }),
+    });
+
+    await controller.start({});
+
+    // Initial focus on list
+    expect(list.style.border.fg).toBe('green');
+
+    // Try to cycle focus — should be suppressed because help is open
+    simulateCtrlWChord(screen, 'w');
+
+    // Focus should NOT have moved
+    expect(list.style.border.fg).toBe('green');
+  });
+
+  it('chord events do not leak when a dialog is open', async () => {
+    const root = makeItem('WL-FOCUS-1');
+    const screen = makeScreen();
+    const { layout, list } = buildLayout(screen);
+    const ctx = buildCtx([root]);
+
+    const controller = new TuiController(ctx, {
+      createLayout: () => layout as any,
+      OpencodeClient: FakeOpencodeClient as any,
+      resolveWorklogDir: () => '/tmp/test-worklog',
+      createPersistence: () => ({
+        loadPersistedState: async () => null,
+        savePersistedState: async () => undefined,
+        statePath: '/tmp/tui-state.json',
+      }),
+    });
+
+    await controller.start({});
+
+    // Simulate the detail modal being open
+    layout.dialogsComponent.detailModal.hidden = false;
+
+    // Try to cycle focus — should be suppressed because dialog is open
+    simulateCtrlWChord(screen, 'w');
+
+    // Focus should NOT have moved from list
+    expect(list.style.border.fg).toBe('green');
+  });
+
+  it('focus wraps around when cycling past the last pane', async () => {
+    const root = makeItem('WL-FOCUS-1');
+    const screen = makeScreen();
+    const { layout, list, detail } = buildLayout(screen);
+    const ctx = buildCtx([root]);
+
+    const controller = new TuiController(ctx, {
+      createLayout: () => layout as any,
+      OpencodeClient: FakeOpencodeClient as any,
+      resolveWorklogDir: () => '/tmp/test-worklog',
+      createPersistence: () => ({
+        loadPersistedState: async () => null,
+        savePersistedState: async () => undefined,
+        statePath: '/tmp/tui-state.json',
+      }),
+    });
+
+    await controller.start({});
+
+    // With opencode dialog hidden, there are 2 panes: list and detail
+    // Cycle forward twice to wrap back to list
+    simulateCtrlWChord(screen, 'w');
+    expect(detail.style.border.fg).toBe('green');
+
+    simulateCtrlWChord(screen, 'w');
+    // Should wrap back to list
+    expect(list.style.border.fg).toBe('green');
+    expect(detail.style.border.fg).toBe('white');
+  });
+
+  it('screen.render is called after each focus change', async () => {
+    const root = makeItem('WL-FOCUS-1');
+    const screen = makeScreen();
+    const { layout } = buildLayout(screen);
+    const ctx = buildCtx([root]);
+
+    const controller = new TuiController(ctx, {
+      createLayout: () => layout as any,
+      OpencodeClient: FakeOpencodeClient as any,
+      resolveWorklogDir: () => '/tmp/test-worklog',
+      createPersistence: () => ({
+        loadPersistedState: async () => null,
+        savePersistedState: async () => undefined,
+        statePath: '/tmp/tui-state.json',
+      }),
+    });
+
+    await controller.start({});
+
+    const renderCountBefore = (screen.render as ReturnType<typeof vi.fn>).mock.calls.length;
+
+    simulateCtrlWChord(screen, 'w');
+
+    const renderCountAfter = (screen.render as ReturnType<typeof vi.fn>).mock.calls.length;
+    expect(renderCountAfter).toBeGreaterThan(renderCountBefore);
+  });
+});

--- a/tests/tui/opencode-layout-integration.test.ts
+++ b/tests/tui/opencode-layout-integration.test.ts
@@ -1,0 +1,497 @@
+/**
+ * Integration tests for TUI opencode layout resizing and textarea.style
+ * object preservation through the TuiController.
+ *
+ * This covers:
+ * - ensureOpencodeTextStyle() never replaces the style object
+ * - clearOpencodeTextBorders() clears border keys in-place
+ * - applyOpencodeCompactLayout() resizes the dialog and textarea correctly
+ * - updateOpencodeInputLayout() adjusts height based on content lines
+ *
+ * Related work item: WL-0MLR6RXK10A4PKH5
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { TuiController } from '../../src/tui/controller.js';
+
+// ── Blessed mock helpers ──────────────────────────────────────────────
+
+const makeBox = () => ({
+  hidden: true,
+  width: 0 as number | string,
+  height: 0 as number | string,
+  top: undefined as number | string | undefined,
+  left: undefined as number | string | undefined,
+  bottom: undefined as number | string | undefined,
+  style: { border: {} as Record<string, any>, label: {} as Record<string, any>, selected: {}, focus: undefined as any },
+  show: vi.fn(function () { (this as any).hidden = false; }),
+  hide: vi.fn(function () { (this as any).hidden = true; }),
+  focus: vi.fn(),
+  setFront: vi.fn(),
+  setContent: vi.fn(),
+  getContent: vi.fn(() => ''),
+  setLabel: vi.fn(),
+  setItems: vi.fn(),
+  select: vi.fn(),
+  getItem: vi.fn(() => undefined),
+  on: vi.fn(),
+  key: vi.fn(),
+  setScroll: vi.fn(),
+  setScrollPerc: vi.fn(),
+  getScroll: vi.fn(() => 0),
+  pushLine: vi.fn(),
+  clearValue: vi.fn(),
+  setValue: vi.fn(),
+  getValue: vi.fn(() => ''),
+  moveCursor: vi.fn(),
+});
+
+const makeList = () => {
+  const list = makeBox() as any;
+  let selected = 0;
+  let items: string[] = [];
+  list.setItems = vi.fn((next: string[]) => {
+    items = next.slice();
+    list.items = items.map(value => ({ getContent: () => value }));
+  });
+  list.select = vi.fn((idx: number) => { selected = idx; });
+  Object.defineProperty(list, 'selected', {
+    get: () => selected,
+    set: (value: number) => { selected = value; },
+  });
+  list.getItem = vi.fn((idx: number) => {
+    const value = items[idx];
+    return value ? { getContent: () => value } : undefined;
+  });
+  list.items = [] as any[];
+  return list;
+};
+
+const makeScreen = () => ({
+  height: 40,
+  width: 120,
+  focused: null as any,
+  render: vi.fn(),
+  destroy: vi.fn(),
+  key: vi.fn(),
+  on: vi.fn(),
+});
+
+// ── Factory for test items ────────────────────────────────────────────
+
+function makeItem(id: string, parentId: string | null = null) {
+  const now = new Date().toISOString();
+  return {
+    id,
+    title: `Item ${id}`,
+    description: '',
+    status: 'open',
+    priority: 'medium',
+    sortIndex: 0,
+    parentId,
+    createdAt: now,
+    updatedAt: now,
+    tags: [],
+    assignee: '',
+    stage: '',
+    issueType: 'task',
+    createdBy: '',
+    deletedBy: '',
+    deleteReason: '',
+    risk: '',
+    effort: '',
+    needsProducerReview: false,
+  };
+}
+
+// ── Helpers ───────────────────────────────────────────────────────────
+
+function buildLayout(screen: any) {
+  const list = makeList();
+  const footer = makeBox();
+  const detail = makeBox();
+  const copyIdButton = makeBox();
+  const overlays = {
+    detailOverlay: makeBox(),
+    closeOverlay: makeBox(),
+    updateOverlay: makeBox(),
+  };
+  const dialogs = {
+    detailModal: makeBox(),
+    detailClose: makeBox(),
+    closeDialog: makeBox(),
+    closeDialogText: makeBox(),
+    closeDialogOptions: makeList(),
+    updateDialog: makeBox(),
+    updateDialogText: makeBox(),
+    updateDialogOptions: makeList(),
+    updateDialogStageOptions: makeList(),
+    updateDialogStatusOptions: makeList(),
+    updateDialogPriorityOptions: makeList(),
+    updateDialogComment: makeBox(),
+  };
+  const helpMenu = {
+    isVisible: vi.fn(() => false),
+    show: vi.fn(),
+    hide: vi.fn(),
+  };
+  const modalDialogs = {
+    selectList: vi.fn(async () => 0),
+    editTextarea: vi.fn(async () => null),
+    confirmTextbox: vi.fn(async () => false),
+    forceCleanup: vi.fn(),
+  };
+
+  // Create textarea and dialog with realistic style objects to test preservation
+  const textarea = makeBox();
+  textarea.style = {
+    border: { fg: 'white', type: 'line' } as Record<string, any>,
+    label: {} as Record<string, any>,
+    selected: {},
+    focus: { border: { fg: 'green' } },
+  };
+
+  const dialog = makeBox();
+
+  const opencodeUi = {
+    serverStatusBox: makeBox(),
+    dialog,
+    textarea,
+    suggestionHint: makeBox(),
+    sendButton: makeBox(),
+    cancelButton: makeBox(),
+    ensureResponsePane: vi.fn(() => makeBox()),
+  };
+
+  return {
+    screen,
+    list,
+    detail,
+    textarea,
+    dialog,
+    layout: {
+      screen,
+      listComponent: { getList: () => list, getFooter: () => footer },
+      detailComponent: { getDetail: () => detail, getCopyIdButton: () => copyIdButton },
+      toastComponent: { show: vi.fn() } as any,
+      overlaysComponent: overlays,
+      dialogsComponent: dialogs,
+      helpMenu,
+      modalDialogs,
+      opencodeUi,
+      nextDialog: {
+        overlay: makeBox(),
+        dialog: makeBox(),
+        close: makeBox(),
+        text: makeBox(),
+        options: makeList(),
+      },
+    },
+  };
+}
+
+function buildCtx(items: any[]) {
+  return {
+    program: { opts: () => ({ verbose: false }) },
+    utils: {
+      requireInitialized: vi.fn(),
+      getDatabase: vi.fn(() => ({
+        list: () => items,
+        getPrefix: () => 'test-prefix',
+        getCommentsForWorkItem: () => [],
+        update: () => ({}),
+        createComment: () => ({}),
+        get: (id: string) => items.find(i => i.id === id) ?? null,
+      })),
+    },
+  } as any;
+}
+
+class FakeOpencodeClient {
+  getStatus() { return { status: 'stopped', port: 9999 }; }
+  startServer() { return Promise.resolve(true); }
+  stopServer() { return undefined; }
+  sendPrompt() { return Promise.resolve(); }
+}
+
+/**
+ * Find a registered screen.key handler that matches the given key(s).
+ */
+function getKeyHandler(mockFn: ReturnType<typeof vi.fn>, keyOrKeys: string | string[]): ((...args: any[]) => any) | null {
+  const keys = Array.isArray(keyOrKeys) ? keyOrKeys : [keyOrKeys];
+  for (const call of mockFn.mock.calls) {
+    const registeredKeys = Array.isArray(call[0]) ? call[0] : [call[0]];
+    if (keys.some(k => registeredKeys.includes(k))) return call[1];
+  }
+  return null;
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────
+
+describe('TUI opencode layout integration', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('textarea.style object reference is preserved after opening opencode dialog', async () => {
+    const root = makeItem('WL-LAYOUT-1');
+    const screen = makeScreen();
+    const { layout, textarea } = buildLayout(screen);
+    const ctx = buildCtx([root]);
+
+    // Capture the original style object reference before the controller touches it
+    const originalStyleRef = textarea.style;
+
+    const controller = new TuiController(ctx, {
+      createLayout: () => layout as any,
+      OpencodeClient: FakeOpencodeClient as any,
+      resolveWorklogDir: () => '/tmp/test-worklog',
+      createPersistence: () => ({
+        loadPersistedState: async () => null,
+        savePersistedState: async () => undefined,
+        statePath: '/tmp/tui-state.json',
+      }),
+    });
+
+    await controller.start({});
+
+    // Open the opencode dialog via the 'o' key handler
+    const openHandler = getKeyHandler(screen.key, ['o', 'O']);
+    if (openHandler) {
+      await openHandler();
+    }
+
+    // The style object must be the SAME reference — not replaced
+    expect(textarea.style).toBe(originalStyleRef);
+  });
+
+  it('textarea border properties are cleared in-place, not by object replacement', async () => {
+    const root = makeItem('WL-LAYOUT-1');
+    const screen = makeScreen();
+    const { layout, textarea } = buildLayout(screen);
+    const ctx = buildCtx([root]);
+
+    // Set up initial border with known properties
+    textarea.style.border = { fg: 'white', type: 'line' } as Record<string, any>;
+    const borderRef = textarea.style.border;
+
+    const controller = new TuiController(ctx, {
+      createLayout: () => layout as any,
+      OpencodeClient: FakeOpencodeClient as any,
+      resolveWorklogDir: () => '/tmp/test-worklog',
+      createPersistence: () => ({
+        loadPersistedState: async () => null,
+        savePersistedState: async () => undefined,
+        statePath: '/tmp/tui-state.json',
+      }),
+    });
+
+    await controller.start({});
+
+    // Open the opencode dialog which triggers applyOpencodeCompactLayout
+    const openHandler = getKeyHandler(screen.key, ['o', 'O']);
+    if (openHandler) {
+      await openHandler();
+    }
+
+    // The border object should be the SAME reference but with properties cleared
+    expect(textarea.style.border).toBe(borderRef);
+    // After clearOpencodeTextBorders, fg and type should be deleted
+    expect(textarea.style.border.fg).toBeUndefined();
+    expect(textarea.style.border.type).toBeUndefined();
+  });
+
+  it('opencode dialog dimensions are set correctly in compact mode', async () => {
+    const root = makeItem('WL-LAYOUT-1');
+    const screen = makeScreen();
+    const { layout, dialog } = buildLayout(screen);
+    const ctx = buildCtx([root]);
+
+    const controller = new TuiController(ctx, {
+      createLayout: () => layout as any,
+      OpencodeClient: FakeOpencodeClient as any,
+      resolveWorklogDir: () => '/tmp/test-worklog',
+      createPersistence: () => ({
+        loadPersistedState: async () => null,
+        savePersistedState: async () => undefined,
+        statePath: '/tmp/tui-state.json',
+      }),
+    });
+
+    await controller.start({});
+
+    // Open the opencode dialog
+    const openHandler = getKeyHandler(screen.key, ['o', 'O']);
+    if (openHandler) {
+      await openHandler();
+    }
+
+    // Dialog should be visible
+    expect(dialog.hidden).toBe(false);
+    // Dialog should be positioned at the bottom
+    expect(dialog.width).toBe('100%');
+    // MIN_INPUT_HEIGHT is 3 (from constants.ts)
+    expect(dialog.height).toBe(3);
+    expect(dialog.left).toBe(0);
+  });
+
+  it('textarea dimensions are set relative to dialog in compact mode', async () => {
+    const root = makeItem('WL-LAYOUT-1');
+    const screen = makeScreen();
+    const { layout, textarea, dialog } = buildLayout(screen);
+    const ctx = buildCtx([root]);
+
+    const controller = new TuiController(ctx, {
+      createLayout: () => layout as any,
+      OpencodeClient: FakeOpencodeClient as any,
+      resolveWorklogDir: () => '/tmp/test-worklog',
+      createPersistence: () => ({
+        loadPersistedState: async () => null,
+        savePersistedState: async () => undefined,
+        statePath: '/tmp/tui-state.json',
+      }),
+    });
+
+    await controller.start({});
+
+    const openHandler = getKeyHandler(screen.key, ['o', 'O']);
+    if (openHandler) {
+      await openHandler();
+    }
+
+    // Textarea should fill the dialog minus borders
+    expect(textarea.top).toBe(0);
+    expect(textarea.left).toBe(0);
+    expect(textarea.width).toBe('100%-2');
+    // height = dialog height (MIN_INPUT_HEIGHT=3) - 2 = 1
+    expect(textarea.height).toBe(1);
+  });
+
+  it('style.focus.border properties are cleared without replacing the focus object', async () => {
+    const root = makeItem('WL-LAYOUT-1');
+    const screen = makeScreen();
+    const { layout, textarea } = buildLayout(screen);
+    const ctx = buildCtx([root]);
+
+    // Set up initial focus.border
+    textarea.style.focus = { border: { fg: 'green' } };
+    const focusRef = textarea.style.focus;
+    const focusBorderRef = textarea.style.focus.border;
+
+    const controller = new TuiController(ctx, {
+      createLayout: () => layout as any,
+      OpencodeClient: FakeOpencodeClient as any,
+      resolveWorklogDir: () => '/tmp/test-worklog',
+      createPersistence: () => ({
+        loadPersistedState: async () => null,
+        savePersistedState: async () => undefined,
+        statePath: '/tmp/tui-state.json',
+      }),
+    });
+
+    await controller.start({});
+
+    const openHandler = getKeyHandler(screen.key, ['o', 'O']);
+    if (openHandler) {
+      await openHandler();
+    }
+
+    // focus object should be the same reference
+    expect(textarea.style.focus).toBe(focusRef);
+    // focus.border should be the same reference but with properties cleared
+    expect(textarea.style.focus.border).toBe(focusBorderRef);
+    expect(textarea.style.focus.border.fg).toBeUndefined();
+  });
+
+  it('textarea style is not null or undefined after layout operations', async () => {
+    const root = makeItem('WL-LAYOUT-1');
+    const screen = makeScreen();
+    const { layout, textarea } = buildLayout(screen);
+    const ctx = buildCtx([root]);
+
+    // Start with a minimal style object
+    textarea.style = { border: {} as Record<string, any>, label: {} as Record<string, any>, selected: {}, focus: undefined };
+
+    const controller = new TuiController(ctx, {
+      createLayout: () => layout as any,
+      OpencodeClient: FakeOpencodeClient as any,
+      resolveWorklogDir: () => '/tmp/test-worklog',
+      createPersistence: () => ({
+        loadPersistedState: async () => null,
+        savePersistedState: async () => undefined,
+        statePath: '/tmp/tui-state.json',
+      }),
+    });
+
+    await controller.start({});
+
+    const openHandler = getKeyHandler(screen.key, ['o', 'O']);
+    if (openHandler) {
+      await openHandler();
+    }
+
+    // Style should never be null or undefined
+    expect(textarea.style).toBeDefined();
+    expect(textarea.style).not.toBeNull();
+    expect(typeof textarea.style).toBe('object');
+  });
+
+  it('opening opencode dialog does not throw even when style starts empty', async () => {
+    const root = makeItem('WL-LAYOUT-1');
+    const screen = makeScreen();
+    const { layout, textarea } = buildLayout(screen);
+    const ctx = buildCtx([root]);
+
+    // Start with completely empty style to ensure ensureOpencodeTextStyle handles it
+    (textarea as any).style = {};
+
+    const controller = new TuiController(ctx, {
+      createLayout: () => layout as any,
+      OpencodeClient: FakeOpencodeClient as any,
+      resolveWorklogDir: () => '/tmp/test-worklog',
+      createPersistence: () => ({
+        loadPersistedState: async () => null,
+        savePersistedState: async () => undefined,
+        statePath: '/tmp/tui-state.json',
+      }),
+    });
+
+    await controller.start({});
+
+    const openHandler = getKeyHandler(screen.key, ['o', 'O']);
+
+    // Should not throw
+    await expect((async () => {
+      if (openHandler) await openHandler();
+    })()).resolves.not.toThrow();
+  });
+
+  it('screen.render is called after layout update', async () => {
+    const root = makeItem('WL-LAYOUT-1');
+    const screen = makeScreen();
+    const { layout } = buildLayout(screen);
+    const ctx = buildCtx([root]);
+
+    const controller = new TuiController(ctx, {
+      createLayout: () => layout as any,
+      OpencodeClient: FakeOpencodeClient as any,
+      resolveWorklogDir: () => '/tmp/test-worklog',
+      createPersistence: () => ({
+        loadPersistedState: async () => null,
+        savePersistedState: async () => undefined,
+        statePath: '/tmp/tui-state.json',
+      }),
+    });
+
+    await controller.start({});
+
+    const renderCountBefore = (screen.render as ReturnType<typeof vi.fn>).mock.calls.length;
+
+    const openHandler = getKeyHandler(screen.key, ['o', 'O']);
+    if (openHandler) {
+      await openHandler();
+    }
+
+    const renderCountAfter = (screen.render as ReturnType<typeof vi.fn>).mock.calls.length;
+    expect(renderCountAfter).toBeGreaterThan(renderCountBefore);
+  });
+});

--- a/tests/tui/persistence-integration.test.ts
+++ b/tests/tui/persistence-integration.test.ts
@@ -1,0 +1,377 @@
+/**
+ * Integration tests for TUI persistence: loading/saving persisted state,
+ * restoring expanded nodes through the TuiController.
+ *
+ * Related work item: WL-0MLR6RP7Y03T0LVU
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { TuiController } from '../../src/tui/controller.js';
+
+// ── Blessed mock helpers ──────────────────────────────────────────────
+
+const makeBox = () => ({
+  hidden: true,
+  width: 0,
+  height: 0,
+  style: { border: {}, label: {}, selected: {} },
+  show: vi.fn(function () { (this as any).hidden = false; }),
+  hide: vi.fn(function () { (this as any).hidden = true; }),
+  focus: vi.fn(),
+  setFront: vi.fn(),
+  setContent: vi.fn(),
+  getContent: vi.fn(() => ''),
+  setLabel: vi.fn(),
+  setItems: vi.fn(),
+  select: vi.fn(),
+  getItem: vi.fn(() => undefined),
+  on: vi.fn(),
+  key: vi.fn(),
+  setScroll: vi.fn(),
+  setScrollPerc: vi.fn(),
+  getScroll: vi.fn(() => 0),
+  pushLine: vi.fn(),
+  clearValue: vi.fn(),
+  setValue: vi.fn(),
+  getValue: vi.fn(() => ''),
+  moveCursor: vi.fn(),
+});
+
+const makeList = () => {
+  const list = makeBox() as any;
+  let selected = 0;
+  let items: string[] = [];
+  list.setItems = vi.fn((next: string[]) => {
+    items = next.slice();
+    list.items = items.map(value => ({ getContent: () => value }));
+  });
+  list.select = vi.fn((idx: number) => { selected = idx; });
+  Object.defineProperty(list, 'selected', {
+    get: () => selected,
+    set: (value: number) => { selected = value; },
+  });
+  list.getItem = vi.fn((idx: number) => {
+    const value = items[idx];
+    return value ? { getContent: () => value } : undefined;
+  });
+  list.items = [] as any[];
+  return list;
+};
+
+const makeScreen = () => ({
+  height: 40,
+  width: 120,
+  focused: null as any,
+  render: vi.fn(),
+  destroy: vi.fn(),
+  key: vi.fn(),
+  on: vi.fn(),
+});
+
+// ── Factory for test items ────────────────────────────────────────────
+
+function makeItem(id: string, parentId: string | null = null) {
+  const now = new Date().toISOString();
+  return {
+    id,
+    title: `Item ${id}`,
+    description: '',
+    status: 'open',
+    priority: 'medium',
+    sortIndex: 0,
+    parentId,
+    createdAt: now,
+    updatedAt: now,
+    tags: [],
+    assignee: '',
+    stage: '',
+    issueType: 'task',
+    createdBy: '',
+    deletedBy: '',
+    deleteReason: '',
+    risk: '',
+    effort: '',
+    needsProducerReview: false,
+  };
+}
+
+// ── Helpers for building a TuiController with persistence spies ───────
+
+interface PersistenceSpy {
+  loadPersistedState: ((prefix?: string) => Promise<any>) & ReturnType<typeof vi.fn>;
+  savePersistedState: ((prefix: string | undefined, state: any) => Promise<void>) & ReturnType<typeof vi.fn>;
+  statePath: string;
+}
+
+function buildLayout(screen: any) {
+  const list = makeList();
+  const footer = makeBox();
+  const detail = makeBox();
+  const copyIdButton = makeBox();
+  const overlays = {
+    detailOverlay: makeBox(),
+    closeOverlay: makeBox(),
+    updateOverlay: makeBox(),
+  };
+  const dialogs = {
+    detailModal: makeBox(),
+    detailClose: makeBox(),
+    closeDialog: makeBox(),
+    closeDialogText: makeBox(),
+    closeDialogOptions: makeList(),
+    updateDialog: makeBox(),
+    updateDialogText: makeBox(),
+    updateDialogOptions: makeList(),
+    updateDialogStageOptions: makeList(),
+    updateDialogStatusOptions: makeList(),
+    updateDialogPriorityOptions: makeList(),
+    updateDialogComment: makeBox(),
+  };
+  const helpMenu = {
+    isVisible: vi.fn(() => false),
+    show: vi.fn(),
+    hide: vi.fn(),
+  };
+  const modalDialogs = {
+    selectList: vi.fn(async () => 0),
+    editTextarea: vi.fn(async () => null),
+    confirmTextbox: vi.fn(async () => false),
+    forceCleanup: vi.fn(),
+  };
+  const opencodeUi = {
+    serverStatusBox: makeBox(),
+    dialog: makeBox(),
+    textarea: makeBox(),
+    suggestionHint: makeBox(),
+    sendButton: makeBox(),
+    cancelButton: makeBox(),
+    ensureResponsePane: vi.fn(() => makeBox()),
+  };
+
+  return {
+    screen,
+    list,
+    detail,
+    layout: {
+      screen,
+      listComponent: { getList: () => list, getFooter: () => footer },
+      detailComponent: { getDetail: () => detail, getCopyIdButton: () => copyIdButton },
+      toastComponent: { show: vi.fn() } as any,
+      overlaysComponent: overlays,
+      dialogsComponent: dialogs,
+      helpMenu,
+      modalDialogs,
+      opencodeUi,
+      nextDialog: {
+        overlay: makeBox(),
+        dialog: makeBox(),
+        close: makeBox(),
+        text: makeBox(),
+        options: makeList(),
+      },
+    },
+  };
+}
+
+function buildCtx(items: any[]) {
+  return {
+    program: { opts: () => ({ verbose: false }) },
+    utils: {
+      requireInitialized: vi.fn(),
+      getDatabase: vi.fn(() => ({
+        list: () => items,
+        getPrefix: () => 'test-prefix',
+        getCommentsForWorkItem: () => [],
+        update: () => ({}),
+        createComment: () => ({}),
+        get: (id: string) => items.find(i => i.id === id) ?? null,
+      })),
+    },
+  } as any;
+}
+
+class FakeOpencodeClient {
+  getStatus() { return { status: 'stopped', port: 9999 }; }
+  startServer() { return Promise.resolve(true); }
+  stopServer() { return undefined; }
+  sendPrompt() { return Promise.resolve(); }
+}
+
+function buildControllerWithPersistence(
+  items: any[],
+  persistenceSpy: PersistenceSpy,
+) {
+  const screen = makeScreen();
+  const { layout, list, detail } = buildLayout(screen);
+
+  const ctx = buildCtx(items);
+
+  const controller = new TuiController(ctx, {
+    createLayout: () => layout as any,
+    OpencodeClient: FakeOpencodeClient as any,
+    resolveWorklogDir: () => '/tmp/test-worklog',
+    createPersistence: (() => persistenceSpy) as any,
+  });
+
+  return { controller, screen, list, detail, persistenceSpy };
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────
+
+describe('TUI persistence integration', () => {
+  let persistenceSpy: PersistenceSpy;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    persistenceSpy = {
+      loadPersistedState: vi.fn(async () => null),
+      savePersistedState: vi.fn(async () => undefined),
+      statePath: '/tmp/test-worklog/tui-state.json',
+    };
+  });
+
+  it('calls loadPersistedState with the database prefix on startup', async () => {
+    const root = makeItem('WL-ROOT-1');
+    const child = makeItem('WL-CHILD-1', 'WL-ROOT-1');
+
+    const { controller } = buildControllerWithPersistence(
+      [root, child],
+      persistenceSpy,
+    );
+
+    await controller.start({});
+
+    expect(persistenceSpy.loadPersistedState).toHaveBeenCalledWith('test-prefix');
+  });
+
+  it('restores expanded nodes from persisted state', async () => {
+    const root = makeItem('WL-ROOT-1');
+    const child = makeItem('WL-CHILD-1', 'WL-ROOT-1');
+
+    // Persisted state says WL-ROOT-1 was expanded
+    persistenceSpy.loadPersistedState = vi.fn(async () => ({
+      expanded: ['WL-ROOT-1'],
+    }));
+
+    const { controller, list } = buildControllerWithPersistence(
+      [root, child],
+      persistenceSpy,
+    );
+
+    await controller.start({});
+
+    // The list should have been rendered with the child visible
+    // (since WL-ROOT-1 is expanded, WL-CHILD-1 should appear)
+    const setItemsCalls = list.setItems.mock.calls;
+    expect(setItemsCalls.length).toBeGreaterThan(0);
+
+    // The last setItems call should include at least 2 items (root + child)
+    const lastItems = setItemsCalls[setItemsCalls.length - 1][0];
+    expect(lastItems.length).toBeGreaterThanOrEqual(2);
+  });
+
+  it('does not expand nodes when persisted state is null', async () => {
+    const root = makeItem('WL-ROOT-1');
+    const child = makeItem('WL-CHILD-1', 'WL-ROOT-1');
+
+    persistenceSpy.loadPersistedState = vi.fn(async () => null);
+
+    const { controller, list } = buildControllerWithPersistence(
+      [root, child],
+      persistenceSpy,
+    );
+
+    await controller.start({});
+
+    // When no persisted state exists, roots are expanded by default,
+    // so children should still be visible
+    const setItemsCalls = list.setItems.mock.calls;
+    expect(setItemsCalls.length).toBeGreaterThan(0);
+  });
+
+  it('saves expanded state on shutdown', async () => {
+    const root = makeItem('WL-ROOT-1');
+
+    persistenceSpy.loadPersistedState = vi.fn(async () => ({
+      expanded: ['WL-ROOT-1'],
+    }));
+
+    const { controller, screen } = buildControllerWithPersistence(
+      [root],
+      persistenceSpy,
+    );
+
+    await controller.start({});
+
+    // Find and invoke the quit handler registered on screen.key
+    const keyCallArgs = (screen.key as ReturnType<typeof vi.fn>).mock.calls;
+    const quitBinding = keyCallArgs.find((call: any[]) => {
+      const keys = Array.isArray(call[0]) ? call[0] : [call[0]];
+      return keys.includes('q') || keys.includes('Q');
+    });
+
+    if (quitBinding) {
+      quitBinding[1](); // invoke handler
+    }
+
+    // savePersistedState should have been called with the prefix
+    expect(persistenceSpy.savePersistedState).toHaveBeenCalled();
+    const saveCalls = persistenceSpy.savePersistedState.mock.calls;
+    // First argument should be the prefix
+    const lastSaveCall = saveCalls[saveCalls.length - 1];
+    expect(lastSaveCall[0]).toBe('test-prefix');
+    // Second argument should contain expanded array
+    expect(lastSaveCall[1]).toHaveProperty('expanded');
+    expect(Array.isArray(lastSaveCall[1].expanded)).toBe(true);
+  });
+
+  it('handles corrupted persisted state gracefully', async () => {
+    const root = makeItem('WL-ROOT-1');
+
+    // Return a state object with non-array expanded (simulate corruption)
+    persistenceSpy.loadPersistedState = vi.fn(async () => ({
+      expanded: 'not-an-array',
+    }));
+
+    const { controller } = buildControllerWithPersistence(
+      [root],
+      persistenceSpy,
+    );
+
+    // Should not throw
+    await expect(controller.start({})).resolves.not.toThrow();
+  });
+
+  it('handles loadPersistedState returning undefined gracefully', async () => {
+    const root = makeItem('WL-ROOT-1');
+
+    persistenceSpy.loadPersistedState = vi.fn(async () => undefined);
+
+    const { controller } = buildControllerWithPersistence(
+      [root],
+      persistenceSpy,
+    );
+
+    // Should not throw
+    await expect(controller.start({})).resolves.not.toThrow();
+  });
+
+  it('prunes expanded IDs for items no longer in the list', async () => {
+    // Persisted state says WL-GONE was expanded, but that item no longer exists
+    const root = makeItem('WL-ROOT-1');
+
+    persistenceSpy.loadPersistedState = vi.fn(async () => ({
+      expanded: ['WL-GONE', 'WL-ROOT-1'],
+    }));
+
+    const { controller, list } = buildControllerWithPersistence(
+      [root],
+      persistenceSpy,
+    );
+
+    await controller.start({});
+
+    // Controller should have started without error, WL-GONE is silently pruned
+    const setItemsCalls = list.setItems.mock.calls;
+    expect(setItemsCalls.length).toBeGreaterThan(0);
+  });
+});


### PR DESCRIPTION
## Summary

Adds 25 new TUI integration tests across 3 test files to improve coverage of persistence, focus cycling, and layout behavior.

### New test files

- **`tests/tui/persistence-integration.test.ts`** (7 tests): Exercises the full persistence flow through `TuiController` — loading/saving persisted state, restoring expanded nodes, handling corrupted state, and pruning stale IDs.

- **`tests/tui/focus-cycling-integration.test.ts`** (10 tests): Validates Ctrl-W chord sequences for cycling and moving focus between panes (list, detail, opencode). Verifies event suppression when help menu or dialogs are open, wrap-around behavior, and that `screen.render` is called after each focus change.

- **`tests/tui/opencode-layout-integration.test.ts`** (8 tests): Regression tests for the crash bug where `textarea.style` object reference was replaced. Verifies in-place border clearing, compact layout dimensions, empty style handling, and style object reference preservation.

### Test results

All 455 tests pass across 56 test files (including 25 new tests).

### Related work items

- WL-0MLB80G0L1AR9HP0 (parent)
- WL-0MLR6RP7Y03T0LVU (persistence tests)
- WL-0MLR6RTM11N96HX5 (focus cycling tests)
- WL-0MLR6RXK10A4PKH5 (layout tests)