### PR TITLE
WL-0MLSHF6TP0Q85BMR: Fix LSP/TypeScript errors

### DIFF
--- a/src/tui/layout.ts
+++ b/src/tui/layout.ts
@@ -89,8 +89,11 @@ export function createLayout(options: CreateLayoutOptions = {}): TuiLayout {
   // Blessed relies on terminfo (tput) which may report only 8 colors even
   // when the terminal actually supports 256.  Modern terminals universally
   // handle 256-color SGR sequences, so this override is safe.
-  if (screen.program?.tput && screen.program.tput.colors < 256) {
-    screen.program.tput.colors = 256;
+  // Cast to any: blessed's program.tput exists at runtime but is missing
+  // from @types/blessed's BlessedProgram declaration.
+  const prog = screen.program as any;
+  if (prog?.tput && prog.tput.colors < 256) {
+    prog.tput.colors = 256;
   }
 
   // ── List (left pane + footer) ───────────────────────────────────────

--- a/tests/cli/cli-inproc.ts
+++ b/tests/cli/cli-inproc.ts
@@ -202,7 +202,7 @@ export async function runInProcess(commandLine: string, timeoutMs: number = 1500
       // runs mirror spawn behaviour. If a command set process.exitCode = 1
       // we should surface that to the caller (execAsync) so tests can treat
       // the invocation as failed.
-       const exitCode = typeof (__inproc_orig_exitcode) === 'number' ? __inproc_orig_exitcode : (typeof process.exitCode === 'number' ? process.exitCode : 0);
+       const exitCode = typeof process.exitCode === 'number' ? process.exitCode : 0;
        return { stdout: out.join(''), stderr: err.join(''), exitCode };
     } catch (e: any) {
       if (e && typeof e.message === 'string' && e.message.startsWith('__INPROC_EXIT__')) {


### PR DESCRIPTION
## Summary

- Remove undefined `__inproc_orig_exitcode` variable reference in `tests/cli/cli-inproc.ts:205`, using `process.exitCode` directly instead
- Cast `screen.program` to `any` in `src/tui/layout.ts` to fix missing `tput` property type error from `@types/blessed`
- Type-level fixes only, no behavioural changes

## Verification

- `npx tsc --noEmit` passes with zero errors
- All 479 tests pass across 59 test files
- `npm run build` succeeds cleanly

Work item: WL-0MLSHF6TP0Q85BMR