### PR TITLE
Fix fresh install failure caused by stats plugin chalk dependency (WL-0MLT5LSM21Y6XNQ9)

### DIFF
--- a/PLUGIN_GUIDE.md
+++ b/PLUGIN_GUIDE.md
@@ -331,6 +331,63 @@ export default function register(ctx) {
 
 Users can then run `worklog --verbose my-cmd` to see detailed output for troubleshooting.
 
+### Handling Dependencies
+
+Plugins are copied into the target project's `.worklog/plugins/` directory, where Node.js resolves imports relative to that location — **not** relative to the Worklog binary. This means any `import` of an npm package (e.g., `import chalk from 'chalk'`) will fail unless that package is installed in the target project's `node_modules`.
+
+To avoid runtime failures, follow one of the strategies below.
+
+#### Self-Contained Plugins (Recommended)
+
+Write plugins with zero external runtime imports. For example, instead of importing `chalk` for colored output, use built-in ANSI escape codes:
+
+```javascript
+const supportsColor = typeof process !== 'undefined'
+  && process.stdout
+  && (process.stdout.isTTY || process.env.FORCE_COLOR);
+
+const wrap = (open, close) => supportsColor
+  ? (str) => `\x1b[${open}m${str}\x1b[${close}m`
+  : (str) => str;
+
+const ansi = {
+  red:           wrap('31', '39'),
+  green:         wrap('32', '39'),
+  blue:          wrap('34', '39'),
+  cyan:          wrap('36', '39'),
+  gray:          wrap('90', '39'),
+  yellowBright:  wrap('93', '39'),
+  // ... add more as needed
+};
+```
+
+This is the approach used by the built-in `stats-plugin.mjs`.
+
+#### Bundling Dependencies
+
+Use a bundler such as [esbuild](https://esbuild.github.io/) or [rollup](https://rollupjs.org/) to produce a single-file plugin with all dependencies inlined:
+
+```bash
+esbuild src/my-plugin.ts --bundle --format=esm --outfile=dist/my-plugin.mjs
+cp dist/my-plugin.mjs .worklog/plugins/
+```
+
+#### Graceful Import Failure
+
+If you want to use an external package when available but degrade gracefully when it is not, use a dynamic `import()` wrapped in a try/catch:
+
+```javascript
+let chalk;
+try {
+  chalk = (await import('chalk')).default;
+} catch {
+  // Provide no-op fallbacks when chalk is unavailable
+  chalk = new Proxy({}, { get: () => (str) => str });
+}
+```
+
+This approach keeps the plugin functional regardless of the host project's dependencies.
+
 ## Configuration
 
 ### Plugin Directory
@@ -401,10 +458,10 @@ worklog --verbose --help
 
 #### Module Resolution Errors
 
-**Problem:** `Cannot find module 'xyz'` error.
+**Problem:** `Cannot find module 'xyz'` or `Cannot find package 'xyz'` error.
 
 **Solutions:**
-- Ensure all dependencies are bundled or available in Node.js
+- Make your plugin self-contained with no external imports (see [Handling Dependencies](#handling-dependencies))
 - Use a bundler (esbuild, rollup) to create a single-file plugin
 - Check that you're exporting as ESM (`export default`)
 
@@ -432,7 +489,7 @@ worklog --verbose --help
 The `examples/` directory contains complete, working plugin examples:
 
 ### [stats-plugin.mjs](examples/stats-plugin.mjs)
-Shows custom work item statistics with database access, JSON mode support, and formatted output.
+Shows custom work item statistics with database access, JSON mode support, and formatted output. This plugin is fully self-contained with no external dependencies (uses built-in ANSI escape codes for colored output).
 Note: running `wl init` will automatically install `examples/stats-plugin.mjs` into your project's `.worklog/plugins/` directory if it is not already present.
 
 ### [bulk-tag-plugin.mjs](examples/bulk-tag-plugin.mjs)
@@ -557,7 +614,7 @@ export default function register(ctx) {
 
 ### Q: Can I use npm packages in my plugin?
 
-**A:** Yes, but you need to bundle them into your plugin file. Use a bundler like esbuild or rollup to create a single-file bundle with all dependencies included.
+**A:** Yes, but you need to bundle them into your plugin file. Use a bundler like esbuild or rollup to create a single-file bundle with all dependencies included. Alternatively, you can make your plugin self-contained by replacing external dependencies with built-in equivalents (see [Handling Dependencies](#handling-dependencies)).
 
 ### Q: Can plugins modify existing commands?
 

--- a/examples/stats-plugin.mjs
+++ b/examples/stats-plugin.mjs
@@ -12,7 +12,43 @@
  * 2. Run: worklog stats
  */
 
-import chalk from 'chalk';
+/**
+ * Lightweight ANSI color helper — replaces the external `chalk` dependency so
+ * the plugin stays self-contained and loads without errors in projects that
+ * don't have chalk installed.
+ *
+ * Each property is a function that wraps a string in the appropriate ANSI
+ * escape sequence.  When stdout is not a TTY (piped / redirected) the
+ * functions return the input unchanged so machine-readable output stays clean.
+ */
+const supportsColor = typeof process !== 'undefined'
+  && process.stdout
+  && (process.stdout.isTTY || process.env.FORCE_COLOR);
+
+const wrap = (open, close) => supportsColor
+  ? (str) => `\x1b[${open}m${str}\x1b[${close}m`
+  : (str) => str;
+
+const ansi = {
+  // Standard colors
+  red:           wrap('31', '39'),
+  green:         wrap('32', '39'),
+  yellow:        wrap('33', '39'),
+  blue:          wrap('34', '39'),
+  magenta:       wrap('35', '39'),
+  cyan:          wrap('36', '39'),
+  white:         wrap('37', '39'),
+  gray:          wrap('90', '39'),
+
+  // Bright colors
+  redBright:     wrap('91', '39'),
+  greenBright:   wrap('92', '39'),
+  yellowBright:  wrap('93', '39'),
+  blueBright:    wrap('94', '39'),
+  magentaBright: wrap('95', '39'),
+  whiteBright:   wrap('97', '39'),
+  cyanBright:    wrap('96', '39'),
+};
 
 export default function register(ctx) {
   ctx.program
@@ -68,15 +104,15 @@ export default function register(ctx) {
             const s = (status || '').toLowerCase().trim();
             switch (s) {
               case 'completed':
-                return chalk.gray;
+                return ansi.gray;
               case 'in-progress':
               case 'in progress':
-                return chalk.cyan;
+                return ansi.cyan;
               case 'blocked':
-                return chalk.redBright;
+                return ansi.redBright;
               case 'open':
               default:
-                return chalk.greenBright;
+                return ansi.greenBright;
             }
           };
 
@@ -84,15 +120,15 @@ export default function register(ctx) {
             const p = (priority || '').toLowerCase().trim();
             switch (p) {
               case 'critical':
-                return chalk.magentaBright;
+                return ansi.magentaBright;
               case 'high':
-                return chalk.yellowBright;
+                return ansi.yellowBright;
               case 'medium':
-                return chalk.blueBright;
+                return ansi.blueBright;
               case 'low':
-                return chalk.whiteBright;
+                return ansi.whiteBright;
               default:
-                return chalk.white;
+                return ansi.white;
             }
           };
 
@@ -218,7 +254,7 @@ export default function register(ctx) {
             statusMaxByColumn[status] = columnMax;
           });
 
-          console.log(`\n${chalk.blue('Status by Priority')}`);
+          console.log(`\n${ansi.blue('Status by Priority')}`);
           const headerLabel = colorizePriority('medium', 'Priority').padEnd(labelWidth);
           const header = [headerLabel, ...statusOrder.map(status => colorizeStatus(status, status.padStart(columnWidth)))].join('  ');
           console.log(`  ${header}`);
@@ -239,7 +275,7 @@ export default function register(ctx) {
             console.log(`  ${row}`);
           });
 
-          console.log(`\n${chalk.blue('By Status')}`);
+          console.log(`\n${ansi.blue('By Status')}`);
           const statusMax = statusEntries.reduce((max, entry) => Math.max(max, entry[1]), 0);
           const statusLabelWidthForTotals = statusEntries.reduce((max, entry) => Math.max(max, entry[0].length), 0);
           const statusCountWidth = Math.max(3, statusEntries.reduce((max, entry) => Math.max(max, entry[1].toString().length), 0));
@@ -265,7 +301,7 @@ export default function register(ctx) {
               console.log(`  ${paddedLabel} ${paddedCount} (${paddedPercent}%) ${stackedBar}`);
             });
 
-          console.log(`\n${chalk.blue('By Priority')}`);
+          console.log(`\n${ansi.blue('By Priority')}`);
           const priorityMax = Object.values(stats.byPriority).reduce((max, value) => Math.max(max, value), 0);
           priorityOrder.forEach(priority => {
             const count = stats.byPriority[priority] || 0;

--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -1188,6 +1188,8 @@ export default function register(ctx: PluginContext): void {
         if (isJsonMode) {
           const gitignoreResult = ensureGitignore({ silent: true });
           const hookResult = installPrePushHook({ silent: true });
+          const postPullResult = installPostPullHooks({ silent: true });
+          const committedHooksResult = installCommittedHooks({ silent: true });
           const agentTemplatePath = locateAgentTemplate();
           if (!agentTemplatePath && isVerbose && !isJsonMode) {
             console.log('Verbose: AGENTS template not found, skipping AGENTS.md update.');
@@ -1210,6 +1212,7 @@ export default function register(ctx: PluginContext): void {
               await ensureWorkflowTemplateInstalled({ silent: true, agentDestinationPath: agentDestination });
             }
           }
+          const statsPluginResult = await ensureStatsPluginInstalled({ silent: true, overwrite: normalizedOptions.statsPluginOverwrite });
           output.json({
             success: true,
             message: 'Configuration initialized',
@@ -1221,7 +1224,10 @@ export default function register(ctx: PluginContext): void {
             initializedAt: initInfo?.initializedAt,
             gitignore: gitignoreResult,
             gitHook: hookResult,
-            agentTemplate: agentTemplateResult
+            postPullHooks: postPullResult,
+            committedHooks: committedHooksResult,
+            agentTemplate: agentTemplateResult,
+            statsPlugin: statsPluginResult
           });
         }
         

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -33,6 +33,11 @@ export class Logger {
     console.log(message);
   }
 
+  warn(message: string): void {
+    // Always write warnings to stderr (like error but semantically distinct)
+    console.error(message);
+  }
+
   error(message: string): void {
     // Always write errors to stderr
     console.error(message);

--- a/src/plugin-loader.ts
+++ b/src/plugin-loader.ts
@@ -163,7 +163,10 @@ export async function loadPlugin(
   } catch (error) {
     const errorMessage = error instanceof Error ? error.message : String(error);
     
-    logger.error(`Failed to load plugin ${name}: ${errorMessage}`);
+    logger.warn(`Warning: plugin ${name} skipped: ${errorMessage}`);
+    if (error instanceof Error && error.stack) {
+      logger.debug(`Plugin ${name} load error stack:\n${error.stack}`);
+    }
     
     return {
       name,

--- a/tests/cli/fresh-install.test.ts
+++ b/tests/cli/fresh-install.test.ts
@@ -1,0 +1,188 @@
+/**
+ * Regression tests for fresh-install plugin loading.
+ *
+ * These tests verify that a fresh project (no node_modules) can run `wl`
+ * commands without plugin-related errors.  They guard against the bug where
+ * the stats plugin imported `chalk`, which could not be resolved relative to
+ * the plugin's location in `.worklog/plugins/`.
+ *
+ * Related work item: WL-0MLU6HA2T0LQNJME
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+  cliPath,
+  execAsync,
+  execWithInput,
+  enterTempDir,
+  leaveTempDir,
+} from './cli-helpers.js';
+import { initRepo } from './git-helpers.js';
+import { createTempDir, cleanupTempDir } from '../test-utils.js';
+
+/** Standard init flags that skip interactive prompts. */
+const INIT_FLAGS = [
+  '--project-name "FreshTest"',
+  '--prefix FRESH',
+  '--auto-export yes',
+  '--auto-sync no',
+  '--workflow-inline no',
+  '--agents-template skip',
+  '--stats-plugin-overwrite no',
+].join(' ');
+
+/**
+ * Extract the first valid JSON object from mixed stdout.
+ *
+ * The first-init code path in init.ts prints non-JSON headings (from
+ * `initConfig`) before emitting the JSON payload.  This helper finds
+ * and parses the first `{...}` JSON object in the output.
+ */
+function extractJson(raw: string): any {
+  const start = raw.indexOf('{');
+  if (start < 0) throw new SyntaxError(`No JSON object found in output: ${raw.slice(0, 200)}`);
+  // Find matching closing brace (handle nested objects)
+  let depth = 0;
+  for (let i = start; i < raw.length; i++) {
+    if (raw[i] === '{') depth++;
+    else if (raw[i] === '}') depth--;
+    if (depth === 0) {
+      return JSON.parse(raw.slice(start, i + 1));
+    }
+  }
+  throw new SyntaxError(`Unmatched braces in JSON output: ${raw.slice(0, 200)}`);
+}
+
+describe('Fresh-install plugin loading', () => {
+  /**
+   * AC 1 -- `wl init --json` in a temp dir must not emit plugin errors on
+   * stderr (no "Failed to load plugin" or "Cannot find package").
+   */
+  it('wl init --json produces clean stderr (no plugin errors)', async () => {
+    const tempState = enterTempDir();
+    try {
+      await initRepo(tempState.tempDir);
+
+      const { stdout, stderr } = await execAsync(
+        `tsx ${cliPath} init --json ${INIT_FLAGS}`,
+      );
+
+      // stderr must not mention plugin loading failures
+      expect(stderr).not.toMatch(/Failed to load plugin/i);
+      expect(stderr).not.toMatch(/Cannot find package/i);
+      expect(stderr).not.toMatch(/Cannot find module/i);
+
+      // stdout contains mixed text; extract the JSON payload
+      const result = extractJson(stdout);
+      expect(result.success).toBe(true);
+    } finally {
+      leaveTempDir(tempState);
+    }
+  });
+
+  /**
+   * AC 2 -- `wl stats --json` works in a fresh project and returns valid JSON
+   * with `success: true`.
+   *
+   * The `stats` command is provided by a plugin, so we must run the full CLI
+   * as a subprocess to ensure the plugin loader is invoked.  We use a separate
+   * temp directory with `cwd` to avoid chdir-related issues with other tests.
+   */
+  it('wl stats --json returns valid JSON after fresh init', async () => {
+    const tempDir = createTempDir();
+    try {
+      await initRepo(tempDir);
+
+      // Init the project (runs as subprocess since it's an init command)
+      await execAsync(
+        `tsx ${cliPath} init ${INIT_FLAGS}`,
+        { cwd: tempDir },
+      );
+
+      // Run stats as a subprocess so plugins get loaded.
+      // execWithInput always spawns a child process (unlike execAsync which
+      // runs non-init commands in-process and would skip plugin loading).
+      const { stdout, stderr, exitCode } = await execWithInput(
+        `tsx ${cliPath} --json stats`,
+        '',
+        { cwd: tempDir },
+      );
+
+      expect(stderr).not.toMatch(/Failed to load plugin/i);
+      expect(stderr).not.toMatch(/Cannot find package/i);
+      expect(stderr).not.toMatch(/Cannot find module/i);
+
+      expect(exitCode).toBe(0);
+      const result = JSON.parse(stdout);
+      expect(result.success).toBe(true);
+    } finally {
+      cleanupTempDir(tempDir);
+    }
+  }, 30000);
+
+  /**
+   * AC 3 -- `wl list --json --verbose` after init must not contain plugin
+   * errors.  The `--verbose` flag should show plugin diagnostic info via
+   * logger.debug, not via error messages.
+   *
+   * We use `execWithInput` to run as a subprocess so the full plugin loader
+   * is exercised.
+   */
+  it('wl list --json --verbose shows no plugin errors', async () => {
+    const tempDir = createTempDir();
+    try {
+      await initRepo(tempDir);
+
+      await execAsync(
+        `tsx ${cliPath} init ${INIT_FLAGS}`,
+        { cwd: tempDir },
+      );
+
+      const { stderr } = await execWithInput(
+        `tsx ${cliPath} --json --verbose list`,
+        '',
+        { cwd: tempDir },
+      );
+
+      expect(stderr).not.toMatch(/Failed to load plugin/i);
+      expect(stderr).not.toMatch(/Cannot find package/i);
+      expect(stderr).not.toMatch(/Cannot find module/i);
+    } finally {
+      cleanupTempDir(tempDir);
+    }
+  }, 30000);
+
+  /**
+   * AC 4+5 -- Running `wl init --json` twice (first-init then re-init) must
+   * include the `statsPlugin` field in both JSON responses, confirming that
+   * both code paths install the stats plugin consistently.
+   */
+  it('first-init and re-init both include statsPlugin in JSON', async () => {
+    const tempState = enterTempDir();
+    try {
+      await initRepo(tempState.tempDir);
+
+      // First init
+      const first = await execAsync(
+        `tsx ${cliPath} init --json ${INIT_FLAGS}`,
+      );
+      const firstResult = extractJson(first.stdout);
+      expect(firstResult.success).toBe(true);
+      expect(firstResult).toHaveProperty('statsPlugin');
+
+      // Re-init (same flags + overwrite no)
+      const second = await execAsync(
+        `tsx ${cliPath} init --json ${INIT_FLAGS}`,
+      );
+      const secondResult = extractJson(second.stdout);
+      expect(secondResult.success).toBe(true);
+      expect(secondResult).toHaveProperty('statsPlugin');
+
+      // Neither should emit plugin errors
+      expect(first.stderr).not.toMatch(/Failed to load plugin/i);
+      expect(second.stderr).not.toMatch(/Failed to load plugin/i);
+    } finally {
+      leaveTempDir(tempState);
+    }
+  });
+});

--- a/tests/plugin-loader.test.ts
+++ b/tests/plugin-loader.test.ts
@@ -203,6 +203,41 @@ describe('Plugin Loader', () => {
       expect(result.error).toContain('Plugin error!');
     });
 
+    it('should emit a single-line warning to stderr when a plugin fails to load', async () => {
+      const program = new Command();
+      const ctx = createPluginContext(program);
+      
+      const pluginPath = path.join(pluginDir, 'warn-plugin.mjs');
+      fs.writeFileSync(pluginPath, `
+        export default function register(ctx) {
+          throw new Error('intentional failure');
+        }
+      `);
+      
+      // Logger.warn() uses console.error(), so intercept that to capture output.
+      const stderrChunks: string[] = [];
+      const origConsoleError = console.error;
+      console.error = (...args: any[]) => {
+        stderrChunks.push(args.map(a => String(a)).join(' '));
+        origConsoleError(...args);
+      };
+
+      try {
+        const result = await loadPlugin(pluginPath, ctx, false);
+        
+        expect(result.loaded).toBe(false);
+        expect(result.error).toContain('intentional failure');
+
+        const stderrOutput = stderrChunks.join('');
+        expect(stderrOutput).toContain('Warning: plugin warn-plugin.mjs skipped:');
+        expect(stderrOutput).toContain('intentional failure');
+        // Should NOT contain old-style error format
+        expect(stderrOutput).not.toContain('Failed to load plugin');
+      } finally {
+        console.error = origConsoleError;
+      }
+    });
+
     it('should fail when plugin file has syntax errors', async () => {
       const program = new Command();
       const ctx = createPluginContext(program);


### PR DESCRIPTION
## Summary

Fixes a bug where `wl init` in a fresh project (no `node_modules`) copies the stats plugin which imports `chalk`. Since chalk can't be resolved relative to the plugin's file location under `.worklog/plugins/`, every subsequent `wl` command emits stderr errors.

## Changes

### 1. Self-contained stats plugin — removed chalk dependency (WL-0MLU6FTG61XXT0RY)
- Replaced `import chalk from 'chalk'` in `examples/stats-plugin.mjs` with a built-in `ansi` helper object that uses raw ANSI escape codes
- All `chalk.xxx()` calls replaced with equivalent `ansi.xxx()` calls
- Plugin now works without any external dependencies

### 2. Graceful plugin load failure handling (WL-0MLU6G7Z71QOTVOB)
- Added `warn()` method to the `Logger` class (`src/logger.ts`)
- Changed `loadPlugin()` in `src/plugin-loader.ts` from `logger.error()` to `logger.warn()` so failed plugins are reported as warnings, not errors
- Stack traces logged via `logger.debug()` only in verbose mode

### 3. Consistent stats plugin init paths (WL-0MLU6GKM40J12M4S)
- Fixed the first-init JSON path in `src/commands/init.ts` to call `installPostPullHooks()`, `installCommittedHooks()`, and `ensureStatsPluginInstalled()`
- Added `postPullHooks`, `committedHooks`, and `statsPlugin` fields to the first-init JSON output, matching the re-init path

### 4. Plugin Guide dependency best practices (WL-0MLU6GVTL1B2VHMS)
- Added "Handling Dependencies" section to `PLUGIN_GUIDE.md` covering self-contained plugins, bundling, and graceful import failure
- Updated troubleshooting and FAQ sections

### 5. Fresh-install regression tests (WL-0MLU6HA2T0LQNJME)
- Created `tests/cli/fresh-install.test.ts` with 4 tests validating clean stderr on init, valid stats JSON output, no plugin errors on list, and consistent statsPlugin field in both init paths
- Fixed `tests/plugin-loader.test.ts` warning test to intercept `console.error` (used by `Logger.warn()`) instead of `process.stderr.write`

## Files Changed

| File | Change |
|------|--------|
| `examples/stats-plugin.mjs` | Replaced chalk with self-contained ANSI helper |
| `src/logger.ts` | Added `warn()` method |
| `src/plugin-loader.ts` | Changed error to warning on plugin load failure |
| `src/commands/init.ts` | Fixed first-init path to install plugins/hooks |
| `PLUGIN_GUIDE.md` | Added dependency best practices section |
| `tests/cli/fresh-install.test.ts` | New: 4 regression tests |
| `tests/plugin-loader.test.ts` | Fixed warning intercept test |

## Testing

All 507 tests pass across 61 test files. Build is clean.