### PR TITLE
WL-0MLSDIRLA0BXRCDB: Add W shortcut to TUI for creating new work items

### DIFF
--- a/TUI.md
+++ b/TUI.md
@@ -26,7 +26,8 @@ This document describes the interactive terminal UI shipped as the `wl tui` (or 
 
 ### Work Item Actions
 
-- n — create new work item
+- W — create new work item (opens a dialog, sends description to OpenCode)
+- n — find next work item recommendation
 - e — edit selected item
 - c — add comment to selected item
 - d — delete selected item

--- a/src/tui/constants.ts
+++ b/src/tui/constants.ts
@@ -96,6 +96,7 @@ export const DEFAULT_SHORTCUTS = [
       { keys: 'M', description: 'Move/reparent item' },
       { keys: 'D', description: 'Toggle do-not-delegate' },
       { keys: 'r/R', description: 'Toggle needs review' },
+      { keys: 'W', description: 'Create new work item' },
     ],
   },
   {
@@ -148,6 +149,7 @@ export const KEY_FILTER_NEEDS_REVIEW = ['v', 'V'];
 export const KEY_TOGGLE_DO_NOT_DELEGATE = ['d', 'D'];
 export const KEY_TOGGLE_NEEDS_REVIEW = ['r', 'R'];
 export const KEY_MOVE = ['m', 'M'];
+export const KEY_CREATE_ITEM = ['w', 'W'];
 
 // Composite keys often used in help menu / close handlers
 export const KEY_MENU_CLOSE = ['escape', 'q'];

--- a/src/tui/controller.ts
+++ b/src/tui/controller.ts
@@ -36,7 +36,7 @@ import ChordHandler from './chords.js';
 import { stripAnsi, stripTags, decorateIdsForClick, extractIdFromLine, extractIdAtColumn, stripTagsAndAnsiWithMap, wrapPlainLineWithMap } from './id-utils.js';
 import { AVAILABLE_COMMANDS, MIN_INPUT_HEIGHT, MAX_INPUT_LINES, FOOTER_HEIGHT, OPENCODE_SERVER_PORT,
   KEY_NAV_RIGHT, KEY_NAV_LEFT, KEY_TOGGLE_EXPAND, KEY_QUIT, KEY_ESCAPE, KEY_TOGGLE_HELP, KEY_CHORD_PREFIX, KEY_CHORD_FOLLOWUPS, KEY_OPEN_OPENCODE, KEY_OPEN_SEARCH,
-  KEY_TAB, KEY_SHIFT_TAB, KEY_LEFT_SINGLE, KEY_RIGHT_SINGLE, KEY_CS, KEY_ENTER, KEY_LINEFEED, KEY_J, KEY_K, KEY_COPY_ID, KEY_PARENT_PREVIEW, KEY_CLOSE_ITEM, KEY_UPDATE_ITEM, KEY_REFRESH, KEY_FIND_NEXT, KEY_FILTER_IN_PROGRESS, KEY_FILTER_OPEN, KEY_FILTER_BLOCKED, KEY_FILTER_NEEDS_REVIEW, KEY_MENU_CLOSE, KEY_TOGGLE_DO_NOT_DELEGATE, KEY_TOGGLE_NEEDS_REVIEW, KEY_MOVE } from './constants.js';
+  KEY_TAB, KEY_SHIFT_TAB, KEY_LEFT_SINGLE, KEY_RIGHT_SINGLE, KEY_CS, KEY_ENTER, KEY_LINEFEED, KEY_J, KEY_K, KEY_COPY_ID, KEY_PARENT_PREVIEW, KEY_CLOSE_ITEM, KEY_UPDATE_ITEM, KEY_REFRESH, KEY_FIND_NEXT, KEY_FILTER_IN_PROGRESS, KEY_FILTER_OPEN, KEY_FILTER_BLOCKED, KEY_FILTER_NEEDS_REVIEW, KEY_MENU_CLOSE, KEY_TOGGLE_DO_NOT_DELEGATE, KEY_TOGGLE_NEEDS_REVIEW, KEY_MOVE, KEY_CREATE_ITEM } from './constants.js';
 import { theme } from '../theme.js';
 
 type Item = WorkItem;
@@ -2712,6 +2712,18 @@ export class TuiController {
         // No legacy pending-state fallback: chordHandler.feed handles all
         // Ctrl-W prefixes and their follow-ups. If chordHandler didn't
         // consume the event we fall through to normal key handlers.
+
+        // Create new work item (W key) — handled here instead of
+        // screen.key to avoid overwriting the Ctrl+W,w chord follow-up
+        // handler in the test mock.
+        const keyName = key?.name;
+        if (keyName === 'w' && !key?.ctrl && !key?.meta) {
+          if (!state.moveMode
+            && detailModal.hidden && !helpMenu.isVisible() && closeDialog.hidden && updateDialog.hidden && nextDialog.hidden
+            && opencodeDialog.hidden) {
+            openCreateItemDialog();
+          }
+        }
       });
 
         // Keep lightweight screen.key wrappers so tests and some widget-level
@@ -2752,6 +2764,10 @@ export class TuiController {
       }
     });
 
+    // Create new work item dialog (shortcut W) — handled in the raw
+    // keypress handler below to avoid conflicting with the Ctrl+W, w
+    // chord follow-up registered via screen.key(KEY_CHORD_FOLLOWUPS).
+
     const restoreListFocus = () => {
       try {
         list.focus();
@@ -2765,6 +2781,30 @@ export class TuiController {
       try { modalDialogs.forceCleanup?.(); } catch (_) {}
       restoreListFocus();
     };
+
+    async function openCreateItemDialog() {
+      try {
+        const description = await modalDialogs.editTextarea({
+          title: 'Create Item',
+          initial: '',
+          confirmLabel: 'Create',
+          cancelLabel: 'Cancel',
+          width: '70%',
+          height: 5,
+        });
+
+        const trimmed = (description || '').trim();
+        if (!trimmed) {
+          restoreListFocus();
+          return;
+        }
+
+        const prompt = 'Create a new work-item for the following description. Assign an appropriate priority and issue-type based on your understanding of the project. Record any dependencies that you can identify. Do not ask clarifying questions, if there is something you truly do not understand use the description verbatum and insert an Open Questions section into the description. \n\n' + trimmed + '.';
+        runOpencode(prompt);
+      } catch (_) {
+        restoreListFocus();
+      }
+    }
 
     // Open search/filter modal (shortcut /)
      screen.key(KEY_OPEN_SEARCH, async () => {


### PR DESCRIPTION
## Summary

- Adds a `W` key shortcut in the TUI that opens a textarea dialog for entering a new work item description
- On submit, the description is sent to OpenCode with a prompt to automatically create and classify the work item (priority, issue-type, dependencies)
- Updates help menu and TUI.md documentation

## Details

The key handling is placed in the raw `screen.on('keypress')` handler rather than `screen.key()` to avoid conflicting with the `Ctrl+W, w` chord follow-up handler (the test mock overwrites the last handler per key). Guards ensure the shortcut is suppressed when modals, move mode, or chord sequences are active.

### Files changed
- `src/tui/constants.ts` — Added `KEY_CREATE_ITEM` constant and help menu entry
- `src/tui/controller.ts` — Added `openCreateItemDialog()` function and `W` key handling in raw keypress handler
- `TUI.md` — Updated documentation with new shortcut

## Testing
- Build passes cleanly (`npm run build`)
- All 539 tests pass (`npm test`)
- No regressions in chord handling or existing TUI shortcuts

## Work Item
WL-0MLSDIRLA0BXRCDB