### PR TITLE
WL-0MLW5FR66175H8YZ: Fix 8 intermittently failing tests

### DIFF
--- a/tests/cli/cli-helpers.ts
+++ b/tests/cli/cli-helpers.ts
@@ -42,7 +42,7 @@ export async function execAsync(command: string, options?: childProcess.ExecOpti
     const originalCwd = process.cwd();
     try {
       if (options?.cwd) process.chdir(options.cwd as string);
-      const res = await runInProcess(command, options?.timeout ?? 15000);
+      const res = await runInProcess(command, options?.timeout ?? 25000);
       if (res.exitCode && res.exitCode !== 0) {
         const error: any = new Error(`Command failed: ${command}`);
         error.stdout = res.stdout ?? '';

--- a/tests/cli/debug-inproc.test.ts
+++ b/tests/cli/debug-inproc.test.ts
@@ -15,4 +15,4 @@ it('debug in-process runner outputs', async () => {
   } finally {
     cleanupTempDir(tmp);
   }
-});
+}, 45000);

--- a/tests/cli/fresh-install.test.ts
+++ b/tests/cli/fresh-install.test.ts
@@ -78,7 +78,7 @@ describe('Fresh-install plugin loading', () => {
     } finally {
       leaveTempDir(tempState);
     }
-  });
+  }, 45000);
 
   /**
    * AC 2 -- `wl stats --json` works in a fresh project and returns valid JSON
@@ -118,7 +118,7 @@ describe('Fresh-install plugin loading', () => {
     } finally {
       cleanupTempDir(tempDir);
     }
-  }, 30000);
+  }, 45000);
 
   /**
    * AC 3 -- `wl list --json --verbose` after init must not contain plugin
@@ -150,7 +150,7 @@ describe('Fresh-install plugin loading', () => {
     } finally {
       cleanupTempDir(tempDir);
     }
-  }, 30000);
+  }, 45000);
 
   /**
    * AC 4+5 -- Running `wl init --json` twice (first-init then re-init) must
@@ -184,5 +184,5 @@ describe('Fresh-install plugin loading', () => {
     } finally {
       leaveTempDir(tempState);
     }
-  });
+  }, 45000);
 });

--- a/tests/cli/init.test.ts
+++ b/tests/cli/init.test.ts
@@ -32,7 +32,7 @@ describe('CLI Init Tests', () => {
     } finally {
       leaveTempDir(tempState);
     }
-  });
+  }, 45000);
 
   it('should not duplicate the AGENTS.md pointer line on re-run', async () => {
     const tempState = enterTempDir();
@@ -52,7 +52,7 @@ describe('CLI Init Tests', () => {
     } finally {
       leaveTempDir(tempState);
     }
-  });
+  }, 45000);
   it('should create semaphore when config exists but semaphore does not', async () => {
     const tempState = enterTempDir();
     try {
@@ -113,7 +113,7 @@ describe('CLI Init Tests', () => {
     } finally {
       leaveTempDir(tempState);
     }
-  });
+  }, 45000);
 
   it('should allow init command without initialization', async () => {
     const tempState = enterTempDir();
@@ -195,7 +195,7 @@ describe('CLI Init Tests', () => {
     } finally {
       cleanupTempDir(tempDir);
     }
-  });
+  }, 45000);
 
   it('should find main repo .worklog when in subdirectory', async () => {
     const tempDir = createTempDir();
@@ -241,5 +241,5 @@ describe('CLI Init Tests', () => {
     } finally {
       cleanupTempDir(tempDir);
     }
-  });
+  }, 45000);
 });

--- a/tests/plugin-integration.test.ts
+++ b/tests/plugin-integration.test.ts
@@ -135,7 +135,7 @@ export default function register(ctx) {
     const result2 = JSON.parse(stdout2);
     expect(result2.success).toBe(true);
     expect(result2.message).toBe('Hello, Copilot!');
-  });
+  }, 45000);
 
   it('should load multiple plugins in lexicographic order', async () => {
     // Create multiple plugins

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -2,8 +2,10 @@ import { defineConfig } from 'vitest/config'
 
 export default defineConfig({
   test: {
-    // Increase default timeout to reduce intermittent test timeouts in CI
-    testTimeout: 20000,
+    // Increase default timeout to reduce intermittent test timeouts in CI.
+    // Tests that spawn tsx subprocesses should set explicit per-test timeouts
+    // (45-60s) since subprocess startup is slow under concurrent load.
+    testTimeout: 30000,
     // Run setup to inject mock git into PATH for spawn-based calls
     setupFiles: ['./tests/setup-tests.ts'],
   },


### PR DESCRIPTION
## Summary

- Fix 8 intermittently failing tests across 5 test files caused by timeout issues under concurrent load
- Increase global `testTimeout` from 20s to 30s in `vitest.config.ts`
- Add explicit 45s timeouts to all subprocess-spawning tests (debug-inproc, fresh-install, init, plugin-integration)
- Increase in-process runner timeout from 15s to 25s in `cli-helpers.ts`

## Root Cause

Tests that spawn `tsx` subprocesses take 15-20s each and exceed the default timeout when running concurrently with the full 562-test suite. They pass individually but fail under load.

## Verification

All 562 tests pass consistently across 2 consecutive full suite runs with no flakiness.

## Files Changed

| File | Change |
|------|--------|
| `vitest.config.ts` | Global testTimeout 20000 -> 30000 |
| `tests/cli/cli-helpers.ts` | In-process runner timeout 15s -> 25s |
| `tests/cli/debug-inproc.test.ts` | Added 45s per-test timeout |
| `tests/cli/fresh-install.test.ts` | Updated 4 tests to 45s timeouts |
| `tests/cli/init.test.ts` | Added 45s timeouts to 5 tests |
| `tests/plugin-integration.test.ts` | Added 45s timeout to first test |

Closes WL-0MLW5FR66175H8YZ