### PR TITLE
github push: pre-filter by last-push timestamp; support DB metadata fallback; add flags & tests

### DIFF
--- a/CLI.md
+++ b/CLI.md
@@ -317,6 +317,11 @@ Mirror work items and comments with GitHub Issues.
 Subcommands:
 
 - `push` — Mirror work items to GitHub Issues. Options: `--repo <owner/name>`, `--label-prefix <prefix>`, `--prefix <prefix>`.
+ - `push` — Mirror work items to GitHub Issues. Options: `--repo <owner/name>`, `--label-prefix <prefix>`, `--prefix <prefix>`.
+   Additional push options:
+
+   - `--force` — Bypass the pre-filter and process all work items regardless of whether they changed since the last push. Useful when you want to re-sync everything.
+   - `--no-update-timestamp` — Do not write the repository last-push timestamp after a successful push. Use this when you want to run a push but avoid advancing the "last pushed" watermark.
 - `import` — Import updates from GitHub Issues. Options: `--repo <owner/name>`, `--label-prefix <prefix>`, `--since <ISO timestamp>`, `--create-new`, `--prefix <prefix>`.
 
 Examples:
@@ -324,6 +329,16 @@ Examples:
 ```sh
 wl github push --repo myorg/myrepo
 wl gh import --repo myorg/myrepo --since 2025-12-01T00:00:00Z --create-new
+
+Examples demonstrating the new push flags:
+
+```sh
+# Force a full re-sync (bypass pre-filter)
+wl github push --repo myorg/myrepo --force
+
+# Push but do not update the recorded last-push timestamp
+wl github push --repo myorg/myrepo --no-update-timestamp
+```
 ```
 
 Example (JSON / label prefix):

--- a/src/commands/github.ts
+++ b/src/commands/github.ts
@@ -40,6 +40,8 @@ export default function register(ctx: PluginContext): void {
     .description('Mirror work items to GitHub Issues')
     .option('--repo <owner/name>', 'GitHub repo (owner/name)')
     .option('--label-prefix <prefix>', 'Label prefix for Worklog labels (default: wl:)')
+    .option('--force', 'Bypass pre-filter and process all items')
+    .option('--no-update-timestamp', 'Do not write last-push timestamp after push')
     .option('--prefix <prefix>', 'Override the default prefix')
     .action(async (options) => {
       utils.requireInitialized();
@@ -87,12 +89,44 @@ export default function register(ctx: PluginContext): void {
         const items = db.getAll();
         const comments = db.getAllComments();
 
+        let itemsToProcess = items;
+        let commentsToProcess = comments;
+        let lastPush: string | null = null;
+        // Pass DB to timestamp helpers when available so they may use metadata
+        const dbForMetadata = typeof db.getAll === 'function' && typeof (db as any).store === 'object' ? (db as any).store : undefined;
+
+        if (options.force) {
+          // Bypass pre-filter when --force specified
+          if (!isJsonMode) console.log('Force push: processing all items (pre-filter bypassed)');
+          logLine('github push: force mode enabled - processing all items');
+        } else {
+          // Pre-filter items to only those changed since last push or never pushed
+          try {
+            const { readLastPushTimestamp, filterItemsForPush } = await import('../github-pre-filter.js');
+            lastPush = readLastPushTimestamp(dbForMetadata);
+            const { filteredItems, filteredComments, totalCandidates, skippedCount } = filterItemsForPush(items, comments, lastPush);
+            itemsToProcess = filteredItems;
+            commentsToProcess = filteredComments;
+            if (!isJsonMode) {
+              console.log(`Processing ${itemsToProcess.length} of ${totalCandidates} items (${skippedCount} skipped, unchanged since last push)`);
+            }
+            logLine(`github push: pre-filtered items lastPush=${lastPush ?? 'none'} processed=${itemsToProcess.length} totalCandidates=${totalCandidates} skipped=${skippedCount}`);
+          } catch (err) {
+            // If pre-filter module fails, fall back to original behavior but log the error
+            const msg = `Pre-filter failed: ${(err as Error).message}. Continuing without pre-filter.`;
+            if (!isJsonMode) console.error(msg);
+            logLine(`github push: ${msg}`);
+            itemsToProcess = items;
+            commentsToProcess = comments;
+          }
+        }
+
         const verboseLog = isVerbose && !isJsonMode
           ? (message: string) => console.log(message)
           : undefined;
         const { updatedItems, result, timing } = await upsertIssuesFromWorkItems(
-          items,
-          comments,
+          itemsToProcess,
+          commentsToProcess,
           githubConfig,
           renderProgress,
           verboseLog,
@@ -104,6 +138,30 @@ export default function register(ctx: PluginContext): void {
         );
         if (updatedItems.length > 0) {
           db.import(updatedItems);
+        }
+
+        // Update the last-push timestamp unless --no-update-timestamp was provided.
+          try {
+            const { writeLastPushTimestamp } = await import('../github-pre-filter.js');
+            const nowIso = new Date().toISOString();
+          // Commander creates a negated option as `updateTimestamp` (true by default)
+          // while some callers may inspect `noUpdateTimestamp`. Support both forms here.
+          const skipUpdateTimestamp = Boolean(options.noUpdateTimestamp) || options.updateTimestamp === false;
+           if (skipUpdateTimestamp) {
+              logLine('github push: skipping last-push timestamp update due to --no-update-timestamp');
+              if (!isJsonMode) console.log('Note: last-push timestamp was not updated (--no-update-timestamp)');
+            } else {
+            writeLastPushTimestamp(nowIso, dbForMetadata);
+            if (options.force) {
+              // In force mode still update timestamp but record that it was a forced push
+              logLine(`github push: force push completed - lastPush updated to ${nowIso}`);
+            } else {
+              logLine(`github push: lastPush updated from ${lastPush ?? 'none'} to ${nowIso}`);
+            }
+          }
+        } catch (_err) {
+          // non-fatal
+          logLine('github push: failed to write last-push timestamp');
         }
 
         logLine(`Repo ${githubConfig.repo}`);
@@ -128,6 +186,7 @@ export default function register(ctx: PluginContext): void {
           console.log(`  Created: ${result.created}`);
           console.log(`  Updated: ${result.updated}`);
           console.log(`  Skipped: ${result.skipped}`);
+          if (options.force) console.log('  Note: --force was used; pre-filter was bypassed');
           if ((result.commentsCreated || 0) > 0 || (result.commentsUpdated || 0) > 0) {
             console.log(`  Comments created: ${result.commentsCreated || 0}`);
             console.log(`  Comments updated: ${result.commentsUpdated || 0}`);

--- a/src/github-pre-filter.ts
+++ b/src/github-pre-filter.ts
@@ -1,0 +1,106 @@
+import { WorkItem, Comment } from './types.js';
+import * as fs from 'fs';
+import * as path from 'path';
+import { resolveWorklogDir } from './worklog-paths.js';
+
+export interface PreFilterResult {
+  filteredItems: WorkItem[];
+  filteredComments: Comment[];
+  totalCandidates: number; // items considered (excluding deleted)
+  skippedCount: number;
+}
+
+const TIMESTAMP_FILENAME = 'github-last-push';
+
+// Prefer DB metadata when available. The WorklogDatabase exposes getMetadata/setMetadata
+// so callers may pass the database instance as the first argument. If db is not
+// provided or metadata access fails we fall back to the file-based implementation
+// for backward compatibility.
+const METADATA_KEY = 'githubLastPush';
+
+export function readLastPushTimestamp(db?: { getMetadata?: (k: string) => string | null }): string | null {
+  // Try DB metadata first when a database instance is provided
+  try {
+    if (db && typeof db.getMetadata === 'function') {
+      const v = db.getMetadata(METADATA_KEY);
+      if (v) return v;
+    }
+  } catch (_err) {
+    // ignore DB metadata read errors and fall back to file
+  }
+
+  try {
+    const dir = resolveWorklogDir();
+    const p = path.join(dir, TIMESTAMP_FILENAME);
+    if (!fs.existsSync(p)) return null;
+    const content = fs.readFileSync(p, { encoding: 'utf8' }).trim();
+    return content || null;
+  } catch (_err) {
+    return null;
+  }
+}
+
+export function writeLastPushTimestamp(ts: string, db?: { setMetadata?: (k: string, v: string) => void }): void {
+  // Try DB metadata when available, but also write the human-friendly file
+  if (db && typeof db.setMetadata === 'function') {
+    try {
+      db.setMetadata(METADATA_KEY, ts);
+    } catch (err) {
+      // Best-effort: log and continue to file write
+      console.error(`Failed to write last-push timestamp to DB metadata: ${(err as Error).message}`);
+    }
+  }
+
+  const dir = resolveWorklogDir();
+  try {
+    // ensure directory exists
+    if (!fs.existsSync(dir)) {
+      fs.mkdirSync(dir, { recursive: true });
+    }
+    const p = path.join(dir, TIMESTAMP_FILENAME);
+    // include a trailing newline for easier human inspection
+    fs.writeFileSync(p, `${ts}\n`, { encoding: 'utf8' });
+  } catch (err) {
+    // best-effort: do not throw, allow CLI to continue
+    console.error(`Failed to write last-push timestamp: ${(err as Error).message}`);
+  }
+}
+
+function isValidIso(iso?: string | null): boolean {
+  if (!iso) return false;
+  const t = new Date(iso).getTime();
+  return !Number.isNaN(t);
+}
+
+export function filterItemsForPush(items: WorkItem[], comments: Comment[], lastPushTimestamp: string | null): PreFilterResult {
+  // Exclude deleted items entirely from consideration
+  const candidates = items.filter(i => i.status !== 'deleted');
+  // If no timestamp recorded, return all candidates and all comments
+  if (!isValidIso(lastPushTimestamp)) {
+    return {
+      filteredItems: candidates,
+      filteredComments: comments.filter(c => candidates.find(i => i.id === c.workItemId)),
+      totalCandidates: candidates.length,
+      skippedCount: 0,
+    };
+  }
+
+  const lastMs = new Date(lastPushTimestamp as string).getTime();
+  const filtered = candidates.filter(item => {
+    // Always include new items that have not yet been pushed
+    if (item.githubIssueNumber == null) return true;
+    const updatedMs = new Date(item.updatedAt).getTime();
+    if (Number.isNaN(updatedMs)) return true; // treat unknown updatedAt as changed
+    return updatedMs > lastMs;
+  });
+
+  const filteredIds = new Set(filtered.map(i => i.id));
+  const filteredComments = comments.filter(c => filteredIds.has(c.workItemId));
+
+  return {
+    filteredItems: filtered,
+    filteredComments,
+    totalCandidates: candidates.length,
+    skippedCount: Math.max(0, candidates.length - filtered.length),
+  };
+}

--- a/tests/cli/github-pre-filter-fallback.test.ts
+++ b/tests/cli/github-pre-filter-fallback.test.ts
@@ -1,0 +1,46 @@
+import { describe, it, expect } from 'vitest';
+import * as fs from 'fs';
+import * as path from 'path';
+import { enterTempDir, leaveTempDir, writeConfig, writeInitSemaphore, seedWorkItems, execAsync, cliPath } from './cli-helpers.js';
+
+// This test simulates the pre-filter module throwing by stubbing the module
+// loader. We achieve this by creating a small shim that shadows the module
+// resolution when running the CLI in-process: the CLI uses dynamic import
+// '../github-pre-filter.js' so we create a file in node_modules to intercept
+// resolution. For simplicity we instead run the CLI child-process and set
+// NODE_OPTIONS to preload a small stub loader. However test harness constraints
+// make this complex; instead assert that when pre-filter fails the CLI still
+// completes and writes the timestamp file. We simulate failure by temporarily
+// renaming the pre-filter file so the import will fail.
+
+describe('github push pre-filter failure fallback', () => {
+  it('falls back to processing all items and writes timestamp when pre-filter import fails', async () => {
+    const state = enterTempDir();
+    try {
+      writeConfig(state.tempDir);
+      writeInitSemaphore(state.tempDir);
+      seedWorkItems(state.tempDir, []);
+
+      const projectRoot = path.resolve(__dirname, '..');
+      const prefilterPath = path.join(projectRoot, 'src', 'github-pre-filter.ts');
+      const tmpPath = `${prefilterPath}.bak`;
+
+      // Temporarily move the pre-filter implementation so dynamic import fails
+      if (fs.existsSync(prefilterPath)) fs.renameSync(prefilterPath, tmpPath);
+
+      const timestampPath = path.join(state.tempDir, '.worklog', 'github-last-push');
+      if (fs.existsSync(timestampPath)) fs.unlinkSync(timestampPath);
+
+      try {
+        await execAsync(`tsx ${cliPath} github push --repo owner/name`, { cwd: state.tempDir });
+      } finally {
+        // restore file
+        if (fs.existsSync(tmpPath)) fs.renameSync(tmpPath, prefilterPath);
+      }
+
+      expect(fs.existsSync(timestampPath)).toBe(true);
+    } finally {
+      leaveTempDir(state);
+    }
+  });
+});

--- a/tests/cli/github-push-force.test.ts
+++ b/tests/cli/github-push-force.test.ts
@@ -1,0 +1,27 @@
+import { describe, it, expect } from 'vitest';
+import * as fs from 'fs';
+import * as path from 'path';
+import { enterTempDir, leaveTempDir, writeConfig, writeInitSemaphore, seedWorkItems, execAsync, cliPath } from './cli-helpers.js';
+
+describe('github push --force timestamp behavior', () => {
+  it('when --force is used timestamp file is still written by default', async () => {
+    const state = enterTempDir();
+    try {
+      writeConfig(state.tempDir);
+      writeInitSemaphore(state.tempDir);
+      seedWorkItems(state.tempDir, []);
+
+      const timestampPath = path.join(state.tempDir, '.worklog', 'github-last-push');
+      if (fs.existsSync(timestampPath)) fs.unlinkSync(timestampPath);
+
+      await execAsync(`tsx ${cliPath} github push --repo owner/name --force`, { cwd: state.tempDir });
+
+      expect(fs.existsSync(timestampPath)).toBe(true);
+      const content = fs.readFileSync(timestampPath, 'utf-8').trim();
+      expect(() => new Date(content)).not.toThrow();
+      expect(isNaN(new Date(content).getTime())).toBe(false);
+    } finally {
+      leaveTempDir(state);
+    }
+  });
+});

--- a/tests/cli/github-push-timestamp.test.ts
+++ b/tests/cli/github-push-timestamp.test.ts
@@ -1,0 +1,48 @@
+import { describe, it, expect } from 'vitest';
+import * as fs from 'fs';
+import * as path from 'path';
+import { enterTempDir, leaveTempDir, writeConfig, writeInitSemaphore, seedWorkItems, execAsync, cliPath } from './cli-helpers.js';
+
+describe('github push --no-update-timestamp', () => {
+  it('does not write .worklog/github-last-push when --no-update-timestamp is used', async () => {
+    const state = enterTempDir();
+    try {
+      writeConfig(state.tempDir);
+      writeInitSemaphore(state.tempDir);
+      // seed no work items so push does minimal work and avoids external GH calls
+      seedWorkItems(state.tempDir, []);
+
+      const timestampPath = path.join(state.tempDir, '.worklog', 'github-last-push');
+      if (fs.existsSync(timestampPath)) fs.unlinkSync(timestampPath);
+
+      // Run the CLI push with --no-update-timestamp
+      await execAsync(`tsx ${cliPath} github push --repo owner/name --no-update-timestamp`, { cwd: state.tempDir });
+
+      expect(fs.existsSync(timestampPath)).toBe(false);
+    } finally {
+      leaveTempDir(state);
+    }
+  });
+
+  it('writes .worklog/github-last-push when flag not provided', async () => {
+    const state = enterTempDir();
+    try {
+      writeConfig(state.tempDir);
+      writeInitSemaphore(state.tempDir);
+      seedWorkItems(state.tempDir, []);
+
+      const timestampPath = path.join(state.tempDir, '.worklog', 'github-last-push');
+      if (fs.existsSync(timestampPath)) fs.unlinkSync(timestampPath);
+
+      await execAsync(`tsx ${cliPath} github push --repo owner/name`, { cwd: state.tempDir });
+
+      expect(fs.existsSync(timestampPath)).toBe(true);
+      const content = fs.readFileSync(timestampPath, 'utf-8').trim();
+      // basic ISO timestamp validation
+      expect(() => new Date(content)).not.toThrow();
+      expect(isNaN(new Date(content).getTime())).toBe(false);
+    } finally {
+      leaveTempDir(state);
+    }
+  });
+});

--- a/tests/github-pre-filter.test.ts
+++ b/tests/github-pre-filter.test.ts
@@ -1,0 +1,79 @@
+import { describe, it, expect } from 'vitest';
+import { filterItemsForPush, readLastPushTimestamp, writeLastPushTimestamp } from '../src/github-pre-filter.js';
+
+const baseTime = new Date('2025-01-01T00:00:00.000Z').toISOString();
+
+function makeItem(id: string, updatedAt: string, githubIssueNumber?: number, status: string = 'open') {
+  return {
+    id,
+    title: id,
+    description: '',
+    status,
+    priority: 'medium',
+    sortIndex: 0,
+    parentId: null,
+    createdAt: baseTime,
+    updatedAt,
+    tags: [],
+    assignee: '',
+    stage: '',
+    issueType: '',
+    createdBy: '',
+    deletedBy: '',
+    deleteReason: '',
+    risk: '',
+    effort: '',
+    githubIssueNumber,
+  } as any;
+}
+
+function makeComment(id: string, workItemId: string) {
+  return { id, workItemId, author: 'a', comment: 'c', createdAt: baseTime, references: [] } as any;
+}
+
+describe('github pre-filter', () => {
+  it('returns all items when no timestamp', () => {
+    const items = [makeItem('A', baseTime), makeItem('B', baseTime)];
+    const comments = [makeComment('C1', 'A'), makeComment('C2', 'B')];
+    const res = filterItemsForPush(items, comments, null);
+    expect(res.filteredItems.length).toBe(2);
+    expect(res.filteredComments.length).toBe(2);
+    expect(res.skippedCount).toBe(0);
+  });
+
+  it('filters unchanged items with githubIssueNumber set', () => {
+    const lastPush = new Date('2025-01-02T00:00:00.000Z').toISOString();
+    const newer = new Date('2025-01-03T00:00:00.000Z').toISOString();
+    const older = new Date('2025-01-01T12:00:00.000Z').toISOString();
+    const items = [makeItem('A', older, 1), makeItem('B', newer, 2), makeItem('C', older) /* no issue number */];
+    const comments = [makeComment('C1', 'A'), makeComment('C2', 'B'), makeComment('C3', 'C')];
+    const res = filterItemsForPush(items, comments, lastPush);
+    // A is older than lastPush and has issue number -> skipped
+    // B is newer -> included
+    // C has no githubIssueNumber -> included
+    expect(res.filteredItems.map(i => i.id).sort()).toEqual(['B', 'C']);
+    expect(res.filteredComments.map(c => c.workItemId).sort()).toEqual(['B', 'C']);
+    expect(res.totalCandidates).toBe(3);
+    expect(res.skippedCount).toBe(1);
+  });
+
+  it('excludes deleted items from candidates', () => {
+    // Use no timestamp so filtering only removes deleted items
+    const items = [makeItem('A', baseTime, 1), makeItem('B', baseTime, undefined, 'deleted')];
+    const comments = [makeComment('C1', 'A'), makeComment('C2', 'B')];
+    const res = filterItemsForPush(items, comments, null);
+    expect(res.totalCandidates).toBe(1);
+    expect(res.filteredItems.map(i => i.id)).toEqual(['A']);
+    expect(res.filteredComments.map(c => c.workItemId)).toEqual(['A']);
+  });
+
+  it('read/write timestamp file roundtrip fallback', () => {
+    // Ensure we can write and read a timestamp via file fallback
+    const now = new Date().toISOString();
+    // write to file (no DB provided)
+    writeLastPushTimestamp(now as string, undefined as any);
+    const read = readLastPushTimestamp(undefined as any);
+    expect(read).toBeTruthy();
+    expect(new Date(read as string).getTime()).toBeGreaterThan(0);
+  });
+});


### PR DESCRIPTION
Implements DB-aware last-push timestamp with file fallback, wires pre-filter to CLI, adds --force and --no-update-timestamp behavior, and includes unit/integration tests.\n\nRelated: WL-0MLWTYXAD01EG7QB.\n\nChanges:\n- src/github-pre-filter.ts: read/write helpers now use DB metadata when available and preserve human-readable file fallback.\n- src/commands/github.ts: pass DB store to timestamp helpers; update logging.\n- tests/*: added unit and integration tests for pre-filter and timestamp behaviors.\n\nNotes:\n- The timestamp is stored in metadata key  when DB is present, and always written to  for human inspection.\n- Created child tasks for additional follow-ups in worklog (tests, docs, migration to DB-only).