### PR TITLE
WL-0MLX34EAV1DGI7QD: fix sub-issue self-link error in github push

### DIFF
--- a/src/github-sync.ts
+++ b/src/github-sync.ts
@@ -412,7 +412,11 @@ export async function upsertIssuesFromWorkItems(
       continue;
     }
     if (parent.githubIssueNumber && item.githubIssueNumber) {
-      linkedPairs.add(`${parent.githubIssueNumber}:${item.githubIssueNumber}`);
+      if (parent.githubIssueNumber === item.githubIssueNumber) {
+        if (onVerboseLog) onVerboseLog(`[hierarchy] skipping self-link: item ${item.id} and parent ${parent.id} both map to GitHub issue #${item.githubIssueNumber}`);
+      } else {
+        linkedPairs.add(`${parent.githubIssueNumber}:${item.githubIssueNumber}`);
+      }
     }
   }
 

--- a/tests/github-sync-self-link.test.ts
+++ b/tests/github-sync-self-link.test.ts
@@ -1,0 +1,170 @@
+/**
+ * Tests for self-link guard in github-sync hierarchy linking.
+ *
+ * When a parent work item and its child both map to the same GitHub issue
+ * number (data corruption), the hierarchy linking phase must skip that pair
+ * instead of attempting to link the issue to itself.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// Mock the github module before importing github-sync
+vi.mock('../src/github.js', () => ({
+  normalizeGithubLabelPrefix: (p?: string) => p || 'wl:',
+  workItemToIssuePayload: (_item: any, _comments: any[], _prefix: string, _all: any[]) => ({
+    title: _item.title,
+    body: '',
+    labels: [],
+    state: _item.status === 'deleted' ? 'closed' : 'open',
+  }),
+  updateGithubIssueAsync: vi.fn(async (_config: any, _num: number, _payload: any) => ({
+    number: _num,
+    id: `ID_${_num}`,
+    updatedAt: new Date().toISOString(),
+  })),
+  createGithubIssueAsync: vi.fn(async (_config: any, _payload: any) => ({
+    number: 999,
+    id: 'ID_999',
+    updatedAt: new Date().toISOString(),
+  })),
+  getGithubIssueAsync: vi.fn(),
+  listGithubIssues: vi.fn(() => []),
+  getGithubIssue: vi.fn(),
+  listGithubIssueComments: vi.fn(() => []),
+  listGithubIssueCommentsAsync: vi.fn(async () => []),
+  createGithubIssueComment: vi.fn(),
+  createGithubIssueCommentAsync: vi.fn(),
+  updateGithubIssueComment: vi.fn(),
+  updateGithubIssueCommentAsync: vi.fn(),
+  stripWorklogMarkers: vi.fn((s: string) => s),
+  extractWorklogId: vi.fn(),
+  extractWorklogCommentId: vi.fn(),
+  extractParentId: vi.fn(),
+  extractParentIssueNumber: vi.fn(),
+  extractChildIds: vi.fn(),
+  extractChildIssueNumbers: vi.fn(),
+  getIssueHierarchy: vi.fn(() => ({ parentIssueNumber: null, childIssueNumbers: [] })),
+  getIssueHierarchyAsync: vi.fn(async () => ({ parentIssueNumber: null, childIssueNumbers: [] })),
+  addSubIssueLink: vi.fn(),
+  addSubIssueLinkResult: vi.fn(() => ({ ok: true })),
+  addSubIssueLinkResultAsync: vi.fn(async () => ({ ok: true })),
+  buildWorklogCommentMarker: vi.fn(),
+  createGithubIssue: vi.fn(),
+  updateGithubIssue: vi.fn(),
+  issueToWorkItemFields: vi.fn(),
+}));
+
+vi.mock('../src/github-metrics.js', () => ({
+  increment: vi.fn(),
+  snapshot: vi.fn(() => ({})),
+  diff: vi.fn(() => ({})),
+}));
+
+import { upsertIssuesFromWorkItems } from '../src/github-sync.js';
+import type { WorkItem } from '../src/types.js';
+
+const baseTime = new Date('2025-01-01T00:00:00.000Z').toISOString();
+
+function makeItem(overrides: Partial<WorkItem> & { id: string }): WorkItem {
+  return {
+    title: overrides.id,
+    description: '',
+    status: 'open',
+    priority: 'medium',
+    sortIndex: 0,
+    parentId: null,
+    createdAt: baseTime,
+    updatedAt: baseTime,
+    tags: [],
+    assignee: '',
+    stage: '',
+    issueType: '',
+    createdBy: '',
+    deletedBy: '',
+    deleteReason: '',
+    risk: '',
+    effort: '',
+    ...overrides,
+  } as WorkItem;
+}
+
+const dummyConfig = {
+  owner: 'test',
+  repo: 'test',
+  token: 'test-token',
+};
+
+describe('github-sync self-link guard', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('skips hierarchy linking when parent and child share the same githubIssueNumber', async () => {
+    const parent = makeItem({
+      id: 'PARENT',
+      githubIssueNumber: 675,
+      githubIssueUpdatedAt: baseTime,
+    });
+    const child = makeItem({
+      id: 'CHILD',
+      parentId: 'PARENT',
+      githubIssueNumber: 675,
+      githubIssueUpdatedAt: baseTime,
+    });
+
+    const verboseMessages: string[] = [];
+    const { result } = await upsertIssuesFromWorkItems(
+      [parent, child],
+      [],
+      dummyConfig as any,
+      undefined,
+      (msg) => verboseMessages.push(msg),
+    );
+
+    // No self-link error should be reported
+    const selfLinkErrors = result.errors.filter(e => e.includes('675->675'));
+    expect(selfLinkErrors).toHaveLength(0);
+
+    // Should have logged a verbose skip message
+    const skipMessages = verboseMessages.filter(m => m.includes('skipping self-link'));
+    expect(skipMessages.length).toBeGreaterThanOrEqual(1);
+    expect(skipMessages[0]).toContain('CHILD');
+    expect(skipMessages[0]).toContain('PARENT');
+    expect(skipMessages[0]).toContain('675');
+
+    // getIssueHierarchyAsync should NOT have been called (no valid pairs to check)
+    const { getIssueHierarchyAsync } = await import('../src/github.js');
+    expect(getIssueHierarchyAsync).not.toHaveBeenCalled();
+  });
+
+  it('still links hierarchy when parent and child have different githubIssueNumbers', async () => {
+    const parent = makeItem({
+      id: 'PARENT',
+      githubIssueNumber: 100,
+      githubIssueUpdatedAt: baseTime,
+    });
+    const child = makeItem({
+      id: 'CHILD',
+      parentId: 'PARENT',
+      githubIssueNumber: 200,
+      githubIssueUpdatedAt: baseTime,
+    });
+
+    const verboseMessages: string[] = [];
+    const { result } = await upsertIssuesFromWorkItems(
+      [parent, child],
+      [],
+      dummyConfig as any,
+      undefined,
+      (msg) => verboseMessages.push(msg),
+    );
+
+    // No self-link skip messages
+    const skipMessages = verboseMessages.filter(m => m.includes('skipping self-link'));
+    expect(skipMessages).toHaveLength(0);
+
+    // getIssueHierarchyAsync should have been called for the parent
+    const { getIssueHierarchyAsync } = await import('../src/github.js');
+    expect(getIssueHierarchyAsync).toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary

- Adds a guard in `src/github-sync.ts` to skip hierarchy linking when a parent work item and its child both map to the same GitHub issue number, preventing the `Sub issue cannot be the same as the parent issue` API error
- Logs a verbose warning when a self-link is detected so the data corruption is visible
- Adds 2 unit tests in `tests/github-sync-self-link.test.ts` validating both the skip and the normal linking paths

## Context

Running `wl gh push --json` produced:
```
link 675->675: gh: An error occured while adding the sub-issue to the parent issue. Sub issue cannot be the same as the parent issue
```

This happened because 33 work items shared `githubIssueNumber: 675` (data corruption in SQLite). The code fix prevents the error even when this data corruption exists. The data corruption itself was fixed separately via direct SQLite update.

## Test Results

All 572 tests pass.

## Work Items

- WL-0MLX34EAV1DGI7QD (parent)
- WL-0MLX34NQI1KZEE3E (self-link guard)
- WL-0MLX34RED18U7KB7 (data fix)