### PR TITLE
WL-0MLVWATCG00J1D05: Extract OpenCode slash-autocomplete into module

### DIFF
--- a/src/tui/controller.ts
+++ b/src/tui/controller.ts
@@ -38,6 +38,7 @@ import { AVAILABLE_COMMANDS, MIN_INPUT_HEIGHT, MAX_INPUT_LINES, FOOTER_HEIGHT, O
   KEY_NAV_RIGHT, KEY_NAV_LEFT, KEY_TOGGLE_EXPAND, KEY_QUIT, KEY_ESCAPE, KEY_TOGGLE_HELP, KEY_CHORD_PREFIX, KEY_CHORD_FOLLOWUPS, KEY_OPEN_OPENCODE, KEY_OPEN_SEARCH,
   KEY_TAB, KEY_SHIFT_TAB, KEY_LEFT_SINGLE, KEY_RIGHT_SINGLE, KEY_CS, KEY_ENTER, KEY_LINEFEED, KEY_J, KEY_K, KEY_COPY_ID, KEY_PARENT_PREVIEW, KEY_CLOSE_ITEM, KEY_UPDATE_ITEM, KEY_REFRESH, KEY_FIND_NEXT, KEY_FILTER_IN_PROGRESS, KEY_FILTER_OPEN, KEY_FILTER_BLOCKED, KEY_FILTER_NEEDS_REVIEW, KEY_MENU_CLOSE, KEY_TOGGLE_DO_NOT_DELEGATE, KEY_TOGGLE_NEEDS_REVIEW, KEY_MOVE } from './constants.js';
 import { theme } from '../theme.js';
+import { initAutocomplete, type AutocompleteInstance } from './opencode-autocomplete.js';
 
 type Item = WorkItem;
 
@@ -711,10 +712,9 @@ export class TuiController {
 
     // Command autocomplete support moved to src/tui/constants.ts
 
-    // Autocomplete state
-    let currentSuggestion = '';
-    let isCommandMode = false;
-    let userTypedText = '';
+    // Autocomplete instance — initialized when the dialog is first opened.
+    let autocompleteInstance: AutocompleteInstance | null = null;
+
     let isWaitingForResponse = false; // Track if we're waiting for OpenCode response
     let isLocalShellRunning = false;
     let localShellProcess: ChildProcess | null = null;
@@ -893,74 +893,23 @@ export class TuiController {
       screen.render();
     };
 
-    // Replace inline applyCommandSuggestion with extracted module usage when
-    // module is initialized below. Keep a fallback for tests that don't wire
-    // the module yet.
+    // Apply the current autocomplete suggestion using the extracted module.
     function applyCommandSuggestion(target: any) {
-      // Prefer using the extracted autocomplete instance when available.
-      try {
-        const inst = (target as any).__opencode_autocomplete;
-        if (inst && typeof inst.applySuggestion === 'function') {
-          const nextValue = inst.applySuggestion(target);
-          if (nextValue) {
-            try { setOpencodeCursorIndex(nextValue, nextValue.length); } catch (_) {}
-            updateOpencodeCursor();
-            isCommandMode = false;
-            currentSuggestion = '';
-            screen.render();
-            return true;
-          }
-        }
-      } catch (_) {}
-
-      if (isCommandMode && currentSuggestion) {
-        const nextValue = currentSuggestion + ' ';
-        try { if (typeof target.setValue === 'function') target.setValue(nextValue); } catch (_) {}
-        setOpencodeCursorIndex(nextValue, nextValue.length);
+      if (!autocompleteInstance) return false;
+      const nextValue = autocompleteInstance.applySuggestion(target);
+      if (nextValue) {
+        try { setOpencodeCursorIndex(nextValue, nextValue.length); } catch (_) {}
         updateOpencodeCursor();
-        currentSuggestion = '';
-        isCommandMode = false;
-        try { suggestionHint.setContent(''); } catch (_) {}
         screen.render();
         return true;
       }
       return false;
     }
 
-    // updateAutocomplete replaced by initAutocomplete usage below. Keep a
-    // tiny wrapper so existing call-sites continue to work until full
-    // migration is done.
+    // Delegate autocomplete updates to the extracted module.
     function updateAutocomplete() {
-      // For backwards compatibility call the module-based updater if present.
-      try {
-        if ((opencodeText as any).__opencode_autocomplete && typeof (opencodeText as any).__opencode_autocomplete.updateFromValue === 'function') {
-          (opencodeText as any).__opencode_autocomplete.updateFromValue();
-          return;
-        }
-      } catch (_) {}
-      // Fallback: simple inline behavior (preserve current behavior)
-      const value = opencodeText.getValue ? opencodeText.getValue() : '';
-      userTypedText = value;
-      const lines = value.split('\n');
-      const commandLine = lines[0];
-      if (commandLine.startsWith('/') && lines.length === 1) {
-        isCommandMode = true;
-        const input = commandLine.toLowerCase();
-        const matches = AVAILABLE_COMMANDS.filter(cmd => cmd.toLowerCase().startsWith(input));
-        if (matches.length > 0 && matches[0] !== input) {
-          currentSuggestion = matches[0];
-          try { suggestionHint.setContent(`{gray-fg}↳ ${currentSuggestion} [Tab]{/gray-fg}`); } catch (_) {}
-          try { suggestionHint.show(); } catch (_) {}
-        } else {
-          currentSuggestion = '';
-          try { suggestionHint.setContent(''); } catch (_) {}
-          try { suggestionHint.hide(); } catch (_) {}
-        }
-      } else {
-        isCommandMode = false;
-        currentSuggestion = '';
-        try { suggestionHint.setContent(''); } catch (_) {}
-        try { suggestionHint.hide(); } catch (_) {}
+      if (autocompleteInstance) {
+        autocompleteInstance.updateFromValue();
       }
       try { updateOpencodeInputLayout(); } catch (_) {}
       screen.render();
@@ -1151,9 +1100,7 @@ export class TuiController {
     const applyOpencodeCompactLayout = (desiredHeight: number) => {
       // When a suggestion is active, grow the dialog by 1 row to make
       // room for the hint line below the textarea.
-      const hasSugg = typeof (opencodeText as any).__opencode_autocomplete?.hasSuggestion === 'function'
-        ? (opencodeText as any).__opencode_autocomplete.hasSuggestion()
-        : (currentSuggestion !== undefined && currentSuggestion !== null && currentSuggestion !== '');
+      const hasSugg = autocompleteInstance?.hasSuggestion() ?? false;
       const extra = hasSugg ? 1 : 0;
       const effectiveHeight = desiredHeight + extra;
 
@@ -1232,9 +1179,7 @@ export class TuiController {
       setOpencodeCursorIndex('', 0);
       
       // Reset autocomplete state
-      currentSuggestion = '';
-      isCommandMode = false;
-      userTypedText = '';
+      if (autocompleteInstance) { autocompleteInstance.reset(); }
       suggestionHint.setContent('');
       opencodeText.focus();
       paneFocusIndex = getFocusPanes().indexOf(opencodeDialog);
@@ -1562,25 +1507,19 @@ export class TuiController {
       };
     try { (opencodeText as any).__opencode_key_k = opencodeTextKHandler; opencodeText.key(KEY_K, opencodeTextKHandler); } catch (_) {}
     
-    // Wire extracted autocomplete module onto the textarea so tests and
-    // other callers can use it. Require the module dynamically to avoid
-    // affecting environments that don't need it (tests will import it).
-    try {
-      // eslint-disable-next-line @typescript-eslint/no-var-requires
-      const initAutocomplete = require('./opencode-autocomplete').default ?? require('./opencode-autocomplete');
-      const instance = initAutocomplete({ textarea: opencodeText, suggestionHint }, {
-        availableCommands: AVAILABLE_COMMANDS,
-        onSuggestionChange: (_active: boolean) => {
-          // Re-run the compact layout so the dialog grows/shrinks to
-          // accommodate the suggestion hint row.
-          try { updateOpencodeInputLayout(); } catch (_) {}
-        },
-      });
-      // expose a reference for tests / future updates
-      (opencodeText as any).__opencode_autocomplete = instance;
-    } catch (_) {
-      // ignore if module can't be loaded
-    }
+    // Initialize the extracted autocomplete module and wire it to the
+    // textarea widget. The module is statically imported at the top of
+    // this file so it is always available.
+    autocompleteInstance = initAutocomplete({ textarea: opencodeText, suggestionHint }, {
+      availableCommands: AVAILABLE_COMMANDS,
+      onSuggestionChange: (_active: boolean) => {
+        // Re-run the compact layout so the dialog grows/shrinks to
+        // accommodate the suggestion hint row.
+        try { updateOpencodeInputLayout(); } catch (_) {}
+      },
+    });
+    // Expose the instance on the widget for tests that inspect it.
+    (opencodeText as any).__opencode_autocomplete = autocompleteInstance;
 
 
     // Pressing Escape while the dialog (or any child) is focused should

--- a/tests/tui/opencode-integration.test.ts
+++ b/tests/tui/opencode-integration.test.ts
@@ -264,21 +264,21 @@ describe('OpenCode autocomplete compact-mode integration', () => {
       await openHandler();
     }
 
-    // If the controller's dynamic require() didn't attach the autocomplete
-    // module (common in test environments), wire it manually so the
-    // integration tests exercise the real module.
+    // The controller now uses a static import and always initializes the
+    // autocomplete module. Verify it was wired correctly.
     if (!(built.textarea as any).__opencode_autocomplete) {
+      // In test environments the controller may not have fully initialized
+      // the autocomplete module (e.g. if blessed mocks prevent start() from
+      // reaching the wiring code). Wire it manually as a test-only fallback.
       const inst = initAutocomplete(
         { textarea: built.textarea, suggestionHint: built.suggestionHint },
         {
           availableCommands: AVAILABLE_COMMANDS,
           onSuggestionChange: (_active: boolean) => {
-            // Mirror the controller's callback: re-run compact layout
             try {
               const value = built.textarea.getValue ? built.textarea.getValue() : '';
               const visualLines = value.split('\n').length;
               const desiredHeight = Math.min(Math.max(MIN_INPUT_HEIGHT, visualLines + 2), 9);
-              // Replicate compact layout logic
               const hasSugg = inst.hasSuggestion();
               const extra = hasSugg ? 1 : 0;
               built.dialog.height = desiredHeight + extra;


### PR DESCRIPTION
## Summary

Complete the extraction of slash-command autocomplete logic from the TUI controller into the dedicated module at `src/tui/opencode-autocomplete.ts`, removing all legacy inline fallback code from the controller.

- **Replaced dynamic `require()` with static ESM import** of `initAutocomplete` and `AutocompleteInstance` type
- **Removed ~93 lines of inline fallback code** from `src/tui/controller.ts` (inline state variables, duplicate matching logic, `__opencode_autocomplete` property lookups)
- **Simplified 4 controller functions** (`applyCommandSuggestion`, `updateAutocomplete`, `applyOpencodeCompactLayout`, dialog reset) to delegate entirely to the autocomplete module API

## Work Item

[WL-0MLVWATCG00J1D05](https://github.com/rgardler-msft/Worklog/issues/716) — Extract OpenCode slash-autocomplete into module

## Changes

### `src/tui/controller.ts` (+32, -93)
- Added static ESM import: `import { initAutocomplete, type AutocompleteInstance } from './opencode-autocomplete.js'`
- Replaced 3 inline state variables (`currentSuggestion`, `isCommandMode`, `userTypedText`) with typed `let autocompleteInstance: AutocompleteInstance | null = null`
- `applyCommandSuggestion()`: removed inline suggestion application logic, now delegates to `autocompleteInstance.applySuggestion()`
- `updateAutocomplete()`: removed inline matching logic, now delegates to `autocompleteInstance.updateFromValue()`
- `applyOpencodeCompactLayout()`: replaced inline state check with `autocompleteInstance?.hasSuggestion() ?? false`
- Dialog open reset: replaced inline state clearing with `autocompleteInstance.reset()`
- Replaced dynamic `require()` block with direct `initAutocomplete()` call

### `tests/tui/opencode-integration.test.ts` (+5, -5)
- Updated comments on manual wiring fallback to reflect static import change

## Testing

- All 572 tests pass (`npm test`)
- All 168 TUI tests pass (`npm run test:tui`)
- Build succeeds (`npm run build`)

## Net impact

+32 lines, -93 lines — significant code reduction with no behavioral change.