### PR TITLE
WL-0MLU6G7Z71QOTVOB: Log full error details in verbose mode when plugin load fails

### DIFF
--- a/src/plugin-loader.ts
+++ b/src/plugin-loader.ts
@@ -164,8 +164,14 @@ export async function loadPlugin(
     const errorMessage = error instanceof Error ? error.message : String(error);
     
     logger.warn(`Warning: plugin ${name} skipped: ${errorMessage}`);
+
+    // In verbose mode, emit full error details (stack trace when available,
+    // otherwise the complete error representation) so users can diagnose
+    // plugin load failures.
     if (error instanceof Error && error.stack) {
       logger.debug(`Plugin ${name} load error stack:\n${error.stack}`);
+    } else {
+      logger.debug(`Plugin ${name} load error details: ${String(error)}`);
     }
     
     return {

--- a/tests/plugin-loader.test.ts
+++ b/tests/plugin-loader.test.ts
@@ -238,6 +238,74 @@ describe('Plugin Loader', () => {
       }
     });
 
+    it('should log full error stack to stderr when verbose is true', async () => {
+      const program = new Command();
+      const ctx = createPluginContext(program);
+      
+      const pluginPath = path.join(pluginDir, 'verbose-plugin.mjs');
+      fs.writeFileSync(pluginPath, `
+        export default function register(ctx) {
+          throw new Error('verbose failure');
+        }
+      `);
+      
+      const stderrChunks: string[] = [];
+      const origConsoleError = console.error;
+      console.error = (...args: any[]) => {
+        stderrChunks.push(args.map(a => String(a)).join(' '));
+      };
+
+      try {
+        const result = await loadPlugin(pluginPath, ctx, true);
+        
+        expect(result.loaded).toBe(false);
+        expect(result.error).toContain('verbose failure');
+
+        const stderrOutput = stderrChunks.join('\n');
+        // Warning line should still be present
+        expect(stderrOutput).toContain('Warning: plugin verbose-plugin.mjs skipped:');
+        // With verbose, the full stack trace should be logged via logger.debug()
+        expect(stderrOutput).toContain('Plugin verbose-plugin.mjs load error stack:');
+        expect(stderrOutput).toContain('verbose failure');
+      } finally {
+        console.error = origConsoleError;
+      }
+    });
+
+    it('should NOT log stack trace to stderr when verbose is false', async () => {
+      const program = new Command();
+      const ctx = createPluginContext(program);
+      
+      const pluginPath = path.join(pluginDir, 'quiet-plugin.mjs');
+      fs.writeFileSync(pluginPath, `
+        export default function register(ctx) {
+          throw new Error('quiet failure');
+        }
+      `);
+      
+      const stderrChunks: string[] = [];
+      const origConsoleError = console.error;
+      console.error = (...args: any[]) => {
+        stderrChunks.push(args.map(a => String(a)).join(' '));
+      };
+
+      try {
+        const result = await loadPlugin(pluginPath, ctx, false);
+        
+        expect(result.loaded).toBe(false);
+        expect(result.error).toContain('quiet failure');
+
+        const stderrOutput = stderrChunks.join('\n');
+        // Warning line should be present
+        expect(stderrOutput).toContain('Warning: plugin quiet-plugin.mjs skipped:');
+        // Without verbose, NO stack trace should appear
+        expect(stderrOutput).not.toContain('load error stack:');
+        expect(stderrOutput).not.toContain('load error details:');
+      } finally {
+        console.error = origConsoleError;
+      }
+    });
+
     it('should fail when plugin file has syntax errors', async () => {
       const program = new Command();
       const ctx = createPluginContext(program);


### PR DESCRIPTION
## Summary

- Ensure `logger.debug()` always emits error details when `--verbose` is set, including for non-Error throwables (fallback to `String()` representation)
- Add test verifying `verbose=true` logs stack trace to stderr
- Add test verifying `verbose=false` suppresses stack trace from stderr

## Work Item

Graceful plugin load failure handling (WL-0MLU6G7Z71QOTVOB)

## Changes

- `src/plugin-loader.ts`: Added `else` branch in the catch block so that when the thrown value is not an `Error` with a `.stack`, `logger.debug()` still logs the full error string representation in verbose mode
- `tests/plugin-loader.test.ts`: Added two tests covering verbose and non-verbose stderr output behavior