### PR TITLE
WL-0MLWTYH2H034D79E: Add last-push timestamp storage module

### DIFF
--- a/src/github-push-state.ts
+++ b/src/github-push-state.ts
@@ -1,0 +1,129 @@
+/**
+ * Local-only per-machine storage for the last successful `wl github push` timestamp.
+ *
+ * Stores state in `.worklog/.local/github-push-state.json` using atomic writes
+ * (write to temp file then rename) to prevent corruption.
+ */
+
+import * as fs from 'fs';
+import * as path from 'path';
+import * as crypto from 'crypto';
+
+export interface GithubPushState {
+  lastPushAt: string;
+}
+
+const LOCAL_DIR = '.local';
+const STATE_FILENAME = 'github-push-state.json';
+
+/**
+ * Read the last-push timestamp from `.worklog/.local/github-push-state.json`.
+ *
+ * @param worklogDir - Absolute path to the `.worklog` directory.
+ * @returns The ISO-8601 timestamp string, or `null` if the file does not exist
+ *          or is malformed.
+ */
+export function readLastPushTimestamp(worklogDir: string): string | null {
+  const filePath = path.join(worklogDir, LOCAL_DIR, STATE_FILENAME);
+
+  if (!fs.existsSync(filePath)) {
+    return null;
+  }
+
+  try {
+    const raw = fs.readFileSync(filePath, { encoding: 'utf8' });
+    const parsed = JSON.parse(raw);
+
+    if (
+      parsed !== null &&
+      typeof parsed === 'object' &&
+      typeof parsed.lastPushAt === 'string' &&
+      parsed.lastPushAt.length > 0
+    ) {
+      // Validate it's a parseable date
+      const ts = new Date(parsed.lastPushAt).getTime();
+      if (Number.isNaN(ts)) {
+        console.warn(
+          `Warning: malformed timestamp in ${filePath}: lastPushAt is not a valid ISO-8601 date`
+        );
+        return null;
+      }
+      return parsed.lastPushAt;
+    }
+
+    console.warn(
+      `Warning: malformed github-push-state.json in ${filePath}: missing or invalid "lastPushAt" field`
+    );
+    return null;
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code === 'ENOENT') {
+      // Race condition: file was removed between existsSync and readFileSync
+      return null;
+    }
+    console.warn(
+      `Warning: failed to read ${filePath}: ${(err as Error).message}`
+    );
+    return null;
+  }
+}
+
+/**
+ * Write the last-push timestamp to `.worklog/.local/github-push-state.json`.
+ *
+ * Uses atomic writes (write to a temp file then rename) to prevent corruption.
+ * Creates the `.worklog/.local/` directory if it does not exist.
+ *
+ * @param worklogDir - Absolute path to the `.worklog` directory.
+ * @param timestamp - ISO-8601 timestamp string to write.
+ * @throws If the `.worklog/.local/` directory cannot be created or the write fails.
+ */
+export function writeLastPushTimestamp(worklogDir: string, timestamp: string): void {
+  const localDir = path.join(worklogDir, LOCAL_DIR);
+
+  // Ensure the .local directory exists; throw with descriptive error if it fails
+  try {
+    let exists = false;
+    try {
+      const stat = fs.statSync(localDir);
+      if (!stat.isDirectory()) {
+        throw new Error(`${localDir} exists but is not a directory`);
+      }
+      exists = true;
+    } catch (statErr) {
+      if ((statErr as NodeJS.ErrnoException).code !== 'ENOENT') {
+        throw statErr;
+      }
+    }
+    if (!exists) {
+      fs.mkdirSync(localDir, { recursive: true });
+    }
+  } catch (err) {
+    throw new Error(
+      `Failed to create directory ${localDir}: ${(err as Error).message}`
+    );
+  }
+
+  const filePath = path.join(localDir, STATE_FILENAME);
+  const state: GithubPushState = { lastPushAt: timestamp };
+  const content = JSON.stringify(state, null, 2) + '\n';
+
+  // Atomic write: write to a temp file in the same directory, then rename
+  const tmpFile = path.join(localDir, `.${STATE_FILENAME}.${crypto.randomBytes(6).toString('hex')}.tmp`);
+
+  try {
+    fs.writeFileSync(tmpFile, content, { encoding: 'utf8' });
+    fs.renameSync(tmpFile, filePath);
+  } catch (err) {
+    // Clean up temp file if rename failed
+    try {
+      if (fs.existsSync(tmpFile)) {
+        fs.unlinkSync(tmpFile);
+      }
+    } catch {
+      // Ignore cleanup errors
+    }
+    throw new Error(
+      `Failed to write ${filePath}: ${(err as Error).message}`
+    );
+  }
+}

--- a/tests/github-push-state.test.ts
+++ b/tests/github-push-state.test.ts
@@ -1,0 +1,254 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import * as fs from 'fs';
+import * as path from 'path';
+import * as os from 'os';
+import { readLastPushTimestamp, writeLastPushTimestamp } from '../src/github-push-state.js';
+
+let tempDir: string;
+let worklogDir: string;
+
+beforeEach(() => {
+  tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'wl-push-state-test-'));
+  worklogDir = path.join(tempDir, '.worklog');
+  fs.mkdirSync(worklogDir, { recursive: true });
+});
+
+afterEach(() => {
+  fs.rmSync(tempDir, { recursive: true, force: true });
+});
+
+describe('readLastPushTimestamp', () => {
+  it('returns null when file does not exist', () => {
+    const result = readLastPushTimestamp(worklogDir);
+    expect(result).toBeNull();
+  });
+
+  it('returns null when .local directory does not exist', () => {
+    const result = readLastPushTimestamp(worklogDir);
+    expect(result).toBeNull();
+  });
+
+  it('reads a valid timestamp', () => {
+    const localDir = path.join(worklogDir, '.local');
+    fs.mkdirSync(localDir, { recursive: true });
+    const ts = '2025-06-15T10:30:00.000Z';
+    fs.writeFileSync(
+      path.join(localDir, 'github-push-state.json'),
+      JSON.stringify({ lastPushAt: ts }, null, 2) + '\n',
+      'utf8'
+    );
+
+    const result = readLastPushTimestamp(worklogDir);
+    expect(result).toBe(ts);
+  });
+
+  it('returns null and warns on malformed JSON', () => {
+    const localDir = path.join(worklogDir, '.local');
+    fs.mkdirSync(localDir, { recursive: true });
+    fs.writeFileSync(
+      path.join(localDir, 'github-push-state.json'),
+      'not valid json!!!',
+      'utf8'
+    );
+
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const result = readLastPushTimestamp(worklogDir);
+    expect(result).toBeNull();
+    expect(warnSpy).toHaveBeenCalledTimes(1);
+    expect(warnSpy.mock.calls[0][0]).toContain('Warning');
+    warnSpy.mockRestore();
+  });
+
+  it('returns null and warns when lastPushAt is missing', () => {
+    const localDir = path.join(worklogDir, '.local');
+    fs.mkdirSync(localDir, { recursive: true });
+    fs.writeFileSync(
+      path.join(localDir, 'github-push-state.json'),
+      JSON.stringify({ foo: 'bar' }),
+      'utf8'
+    );
+
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const result = readLastPushTimestamp(worklogDir);
+    expect(result).toBeNull();
+    expect(warnSpy).toHaveBeenCalledTimes(1);
+    expect(warnSpy.mock.calls[0][0]).toContain('malformed');
+    warnSpy.mockRestore();
+  });
+
+  it('returns null and warns when lastPushAt is not a valid date', () => {
+    const localDir = path.join(worklogDir, '.local');
+    fs.mkdirSync(localDir, { recursive: true });
+    fs.writeFileSync(
+      path.join(localDir, 'github-push-state.json'),
+      JSON.stringify({ lastPushAt: 'not-a-date' }),
+      'utf8'
+    );
+
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const result = readLastPushTimestamp(worklogDir);
+    expect(result).toBeNull();
+    expect(warnSpy).toHaveBeenCalledTimes(1);
+    expect(warnSpy.mock.calls[0][0]).toContain('malformed');
+    warnSpy.mockRestore();
+  });
+
+  it('returns null and warns when lastPushAt is an empty string', () => {
+    const localDir = path.join(worklogDir, '.local');
+    fs.mkdirSync(localDir, { recursive: true });
+    fs.writeFileSync(
+      path.join(localDir, 'github-push-state.json'),
+      JSON.stringify({ lastPushAt: '' }),
+      'utf8'
+    );
+
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const result = readLastPushTimestamp(worklogDir);
+    expect(result).toBeNull();
+    expect(warnSpy).toHaveBeenCalledTimes(1);
+    warnSpy.mockRestore();
+  });
+
+  it('returns null and warns when lastPushAt is a number', () => {
+    const localDir = path.join(worklogDir, '.local');
+    fs.mkdirSync(localDir, { recursive: true });
+    fs.writeFileSync(
+      path.join(localDir, 'github-push-state.json'),
+      JSON.stringify({ lastPushAt: 12345 }),
+      'utf8'
+    );
+
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const result = readLastPushTimestamp(worklogDir);
+    expect(result).toBeNull();
+    expect(warnSpy).toHaveBeenCalledTimes(1);
+    warnSpy.mockRestore();
+  });
+
+  it('returns null and warns when file contains null', () => {
+    const localDir = path.join(worklogDir, '.local');
+    fs.mkdirSync(localDir, { recursive: true });
+    fs.writeFileSync(
+      path.join(localDir, 'github-push-state.json'),
+      'null',
+      'utf8'
+    );
+
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const result = readLastPushTimestamp(worklogDir);
+    expect(result).toBeNull();
+    warnSpy.mockRestore();
+  });
+});
+
+describe('writeLastPushTimestamp', () => {
+  it('writes a valid timestamp file', () => {
+    const ts = '2025-06-15T10:30:00.000Z';
+    writeLastPushTimestamp(worklogDir, ts);
+
+    const filePath = path.join(worklogDir, '.local', 'github-push-state.json');
+    expect(fs.existsSync(filePath)).toBe(true);
+
+    const content = fs.readFileSync(filePath, 'utf8');
+    const parsed = JSON.parse(content);
+    expect(parsed).toEqual({ lastPushAt: ts });
+  });
+
+  it('creates .local directory if it does not exist', () => {
+    const localDir = path.join(worklogDir, '.local');
+    expect(fs.existsSync(localDir)).toBe(false);
+
+    const ts = new Date().toISOString();
+    writeLastPushTimestamp(worklogDir, ts);
+
+    expect(fs.existsSync(localDir)).toBe(true);
+    expect(fs.statSync(localDir).isDirectory()).toBe(true);
+  });
+
+  it('overwrites an existing file', () => {
+    const ts1 = '2025-01-01T00:00:00.000Z';
+    const ts2 = '2025-06-15T10:30:00.000Z';
+
+    writeLastPushTimestamp(worklogDir, ts1);
+    writeLastPushTimestamp(worklogDir, ts2);
+
+    const filePath = path.join(worklogDir, '.local', 'github-push-state.json');
+    const content = fs.readFileSync(filePath, 'utf8');
+    const parsed = JSON.parse(content);
+    expect(parsed.lastPushAt).toBe(ts2);
+  });
+
+  it('does not leave temp files on success', () => {
+    const ts = new Date().toISOString();
+    writeLastPushTimestamp(worklogDir, ts);
+
+    const localDir = path.join(worklogDir, '.local');
+    const files = fs.readdirSync(localDir);
+    // Only the state file should exist
+    expect(files).toEqual(['github-push-state.json']);
+  });
+
+  it('throws with descriptive error when directory cannot be created', () => {
+    // Create a file where the .local directory should be so mkdir fails
+    const localPath = path.join(worklogDir, '.local');
+    fs.writeFileSync(localPath, 'blocker', 'utf8');
+
+    expect(() => {
+      writeLastPushTimestamp(worklogDir, new Date().toISOString());
+    }).toThrow(/Failed to create directory/);
+  });
+
+  it('throws with descriptive error when write fails', () => {
+    const localDir = path.join(worklogDir, '.local');
+    fs.mkdirSync(localDir, { recursive: true });
+
+    // Make the directory read-only so writeFileSync fails
+    fs.chmodSync(localDir, 0o444);
+
+    try {
+      expect(() => {
+        writeLastPushTimestamp(worklogDir, new Date().toISOString());
+      }).toThrow(/Failed to write/);
+    } finally {
+      // Restore permissions for cleanup
+      fs.chmodSync(localDir, 0o755);
+    }
+  });
+});
+
+describe('read/write roundtrip', () => {
+  it('roundtrips a timestamp correctly', () => {
+    const ts = '2025-06-15T10:30:00.000Z';
+    writeLastPushTimestamp(worklogDir, ts);
+
+    const result = readLastPushTimestamp(worklogDir);
+    expect(result).toBe(ts);
+  });
+
+  it('handles multiple sequential writes and reads', () => {
+    const timestamps = [
+      '2025-01-01T00:00:00.000Z',
+      '2025-03-15T12:00:00.000Z',
+      '2025-06-15T10:30:00.000Z',
+    ];
+
+    for (const ts of timestamps) {
+      writeLastPushTimestamp(worklogDir, ts);
+      const result = readLastPushTimestamp(worklogDir);
+      expect(result).toBe(ts);
+    }
+  });
+
+  it('file format contains pretty-printed JSON with trailing newline', () => {
+    const ts = '2025-06-15T10:30:00.000Z';
+    writeLastPushTimestamp(worklogDir, ts);
+
+    const filePath = path.join(worklogDir, '.local', 'github-push-state.json');
+    const raw = fs.readFileSync(filePath, 'utf8');
+
+    // Should be pretty-printed with 2-space indent
+    expect(raw).toBe(JSON.stringify({ lastPushAt: ts }, null, 2) + '\n');
+    // Should end with a newline
+    expect(raw.endsWith('\n')).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary

Implements local-only per-machine storage for the last successful `wl github push` timestamp, as specified in WL-0MLWTYH2H034D79E. This is a foundational module that enables the parent feature (WL-0MLWQZTR20CICVO7) to skip unchanged items on subsequent pushes.

## Work Done

- **New module `src/github-push-state.ts`** with two exported functions:
  - `readLastPushTimestamp(worklogDir)` - Reads and validates JSON from `.worklog/.local/github-push-state.json`, returns `null` on missing/malformed files with `console.warn` logging
  - `writeLastPushTimestamp(worklogDir, timestamp)` - Atomic writes via temp file + rename, creates `.local/` directory if needed, throws descriptive errors on permission failures
- **Comprehensive test suite** (`tests/github-push-state.test.ts`) with 18 unit tests covering:
  - Missing file / missing directory returns `null`
  - Valid timestamp read/write roundtrip
  - Malformed JSON returns `null` + warning
  - Missing/invalid `lastPushAt` field returns `null` + warning
  - Invalid date string returns `null` + warning
  - Empty string, number, and null values handled correctly
  - Directory auto-creation
  - File overwrite
  - No temp file leaks on success
  - Permission errors throw descriptive messages
  - Pretty-printed JSON with trailing newline

## Key Design Decisions

- Uses `crypto.randomBytes(6)` for unique temp file names during atomic writes
- Validates both JSON structure AND date parseability on read
- Handles TOCTOU race condition (file removed between existsSync and readFileSync)
- Checks that `.local` path is actually a directory, not a file that happens to exist at that path

## How to Test

```bash
npm test -- tests/github-push-state.test.ts
```

All 609 tests pass, build is clean.

## Review Focus

- Correctness of atomic write pattern (write + rename)
- Error handling completeness (malformed files, permission errors, race conditions)
- API design (function signatures match what downstream consumers in WL-0MLWQZTR20CICVO7 will need)

## Related Work Items

- Parent: WL-0MLWQZTR20CICVO7 (wl gh push should only push items that have been changed since the last time it was run)
- This item: WL-0MLWTYH2H034D79E (Last-push timestamp storage)