### PR TITLE
WL-0MLWTYXAD01EG7QB: Comprehensive pre-filter unit tests for github push

### DIFF
--- a/tests/github-pre-filter.test.ts
+++ b/tests/github-pre-filter.test.ts
@@ -32,48 +32,344 @@ function makeComment(id: string, workItemId: string) {
 }
 
 describe('github pre-filter', () => {
-  it('returns all items when no timestamp', () => {
-    const items = [makeItem('A', baseTime), makeItem('B', baseTime)];
-    const comments = [makeComment('C1', 'A'), makeComment('C2', 'B')];
-    const res = filterItemsForPush(items, comments, null);
-    expect(res.filteredItems.length).toBe(2);
-    expect(res.filteredComments.length).toBe(2);
-    expect(res.skippedCount).toBe(0);
+  // -------------------------------------------------------------------
+  // AC4: On first run (no timestamp file), all items are processed
+  // -------------------------------------------------------------------
+  describe('first run / no timestamp', () => {
+    it('returns all items when lastPushTimestamp is null', () => {
+      const items = [makeItem('A', baseTime), makeItem('B', baseTime)];
+      const comments = [makeComment('C1', 'A'), makeComment('C2', 'B')];
+      const res = filterItemsForPush(items, comments, null);
+      expect(res.filteredItems.length).toBe(2);
+      expect(res.filteredComments.length).toBe(2);
+      expect(res.skippedCount).toBe(0);
+      expect(res.totalCandidates).toBe(2);
+    });
+
+    it('returns all items when lastPushTimestamp is empty string', () => {
+      const items = [makeItem('A', baseTime, 1), makeItem('B', baseTime)];
+      const comments = [makeComment('C1', 'A')];
+      const res = filterItemsForPush(items, comments, '');
+      expect(res.filteredItems.length).toBe(2);
+      expect(res.skippedCount).toBe(0);
+    });
+
+    it('returns all items when lastPushTimestamp is invalid ISO string', () => {
+      const items = [makeItem('A', baseTime, 1), makeItem('B', baseTime)];
+      const comments: any[] = [];
+      const res = filterItemsForPush(items, comments, 'not-a-date');
+      expect(res.filteredItems.length).toBe(2);
+      expect(res.skippedCount).toBe(0);
+    });
   });
 
-  it('filters unchanged items with githubIssueNumber set', () => {
+  // -------------------------------------------------------------------
+  // AC1: Only items where updatedAt > lastPushTimestamp OR
+  //      githubIssueNumber is null/undefined are processed
+  // -------------------------------------------------------------------
+  describe('pre-filter with valid timestamp', () => {
+    const lastPush = new Date('2025-01-02T00:00:00.000Z').toISOString();
+
+    it('includes items with updatedAt newer than lastPush', () => {
+      const newer = new Date('2025-01-03T00:00:00.000Z').toISOString();
+      const items = [makeItem('A', newer, 1)];
+      const res = filterItemsForPush(items, [], lastPush);
+      expect(res.filteredItems.map(i => i.id)).toEqual(['A']);
+      expect(res.skippedCount).toBe(0);
+    });
+
+    it('includes items with no githubIssueNumber (null)', () => {
+      const older = new Date('2025-01-01T00:00:00.000Z').toISOString();
+      const items = [makeItem('A', older, undefined)]; // undefined becomes null-ish
+      const res = filterItemsForPush(items, [], lastPush);
+      expect(res.filteredItems.map(i => i.id)).toEqual(['A']);
+    });
+
+    it('includes items with githubIssueNumber explicitly undefined', () => {
+      const older = new Date('2025-01-01T00:00:00.000Z').toISOString();
+      const item = makeItem('A', older);
+      item.githubIssueNumber = undefined;
+      const res = filterItemsForPush([item], [], lastPush);
+      expect(res.filteredItems.map(i => i.id)).toEqual(['A']);
+    });
+
+    it('filters unchanged items with githubIssueNumber set', () => {
+      const newer = new Date('2025-01-03T00:00:00.000Z').toISOString();
+      const older = new Date('2025-01-01T12:00:00.000Z').toISOString();
+      const items = [makeItem('A', older, 1), makeItem('B', newer, 2), makeItem('C', older) /* no issue number */];
+      const comments = [makeComment('C1', 'A'), makeComment('C2', 'B'), makeComment('C3', 'C')];
+      const res = filterItemsForPush(items, comments, lastPush);
+      // A is older than lastPush and has issue number -> skipped
+      // B is newer -> included
+      // C has no githubIssueNumber -> included
+      expect(res.filteredItems.map(i => i.id).sort()).toEqual(['B', 'C']);
+      expect(res.filteredComments.map(c => c.workItemId).sort()).toEqual(['B', 'C']);
+      expect(res.totalCandidates).toBe(3);
+      expect(res.skippedCount).toBe(1);
+    });
+
+    // AC5: Items with updatedAt <= lastPushTimestamp AND existing
+    //      githubIssueNumber are NOT processed
+    it('skips items with updatedAt equal to lastPushTimestamp', () => {
+      // Equal timestamps should NOT be processed (strict >)
+      const items = [makeItem('A', lastPush, 1)];
+      const res = filterItemsForPush(items, [], lastPush);
+      expect(res.filteredItems.length).toBe(0);
+      expect(res.skippedCount).toBe(1);
+    });
+
+    it('skips items with updatedAt older than lastPushTimestamp', () => {
+      const older = new Date('2025-01-01T00:00:00.000Z').toISOString();
+      const items = [makeItem('A', older, 5)];
+      const res = filterItemsForPush(items, [], lastPush);
+      expect(res.filteredItems.length).toBe(0);
+      expect(res.skippedCount).toBe(1);
+    });
+
+    it('treats items with invalid updatedAt as changed (included)', () => {
+      const items = [makeItem('A', 'not-a-date', 1)];
+      const res = filterItemsForPush(items, [], lastPush);
+      // NaN updatedAt should be treated as changed
+      expect(res.filteredItems.map(i => i.id)).toEqual(['A']);
+      expect(res.skippedCount).toBe(0);
+    });
+  });
+
+  // -------------------------------------------------------------------
+  // AC2: Items with status === 'deleted' are excluded from this filter
+  // -------------------------------------------------------------------
+  describe('deleted item exclusion', () => {
+    it('excludes deleted items from candidates', () => {
+      const items = [makeItem('A', baseTime, 1), makeItem('B', baseTime, undefined, 'deleted')];
+      const comments = [makeComment('C1', 'A'), makeComment('C2', 'B')];
+      const res = filterItemsForPush(items, comments, null);
+      expect(res.totalCandidates).toBe(1);
+      expect(res.filteredItems.map(i => i.id)).toEqual(['A']);
+      expect(res.filteredComments.map(c => c.workItemId)).toEqual(['A']);
+    });
+
+    it('excludes deleted items even when they have a githubIssueNumber', () => {
+      const lastPush = new Date('2025-01-02T00:00:00.000Z').toISOString();
+      const newer = new Date('2025-01-03T00:00:00.000Z').toISOString();
+      const items = [makeItem('A', newer, 10, 'deleted')];
+      const res = filterItemsForPush(items, [], lastPush);
+      expect(res.filteredItems.length).toBe(0);
+      expect(res.totalCandidates).toBe(0);
+      expect(res.skippedCount).toBe(0);
+    });
+
+    it('excludes deleted items from totalCandidates count', () => {
+      const items = [
+        makeItem('A', baseTime, 1),
+        makeItem('B', baseTime, 2, 'deleted'),
+        makeItem('C', baseTime, 3, 'deleted'),
+      ];
+      const res = filterItemsForPush(items, [], null);
+      expect(res.totalCandidates).toBe(1);
+    });
+  });
+
+  // -------------------------------------------------------------------
+  // AC6: Comments are also filtered to only include those belonging
+  //      to pre-filtered items
+  // -------------------------------------------------------------------
+  describe('comment filtering', () => {
     const lastPush = new Date('2025-01-02T00:00:00.000Z').toISOString();
     const newer = new Date('2025-01-03T00:00:00.000Z').toISOString();
-    const older = new Date('2025-01-01T12:00:00.000Z').toISOString();
-    const items = [makeItem('A', older, 1), makeItem('B', newer, 2), makeItem('C', older) /* no issue number */];
-    const comments = [makeComment('C1', 'A'), makeComment('C2', 'B'), makeComment('C3', 'C')];
-    const res = filterItemsForPush(items, comments, lastPush);
-    // A is older than lastPush and has issue number -> skipped
-    // B is newer -> included
-    // C has no githubIssueNumber -> included
-    expect(res.filteredItems.map(i => i.id).sort()).toEqual(['B', 'C']);
-    expect(res.filteredComments.map(c => c.workItemId).sort()).toEqual(['B', 'C']);
-    expect(res.totalCandidates).toBe(3);
-    expect(res.skippedCount).toBe(1);
+    const older = new Date('2025-01-01T00:00:00.000Z').toISOString();
+
+    it('includes comments for items that pass the filter', () => {
+      const items = [makeItem('A', newer, 1)];
+      const comments = [makeComment('C1', 'A'), makeComment('C2', 'A')];
+      const res = filterItemsForPush(items, comments, lastPush);
+      expect(res.filteredComments.length).toBe(2);
+    });
+
+    it('excludes comments for items that are filtered out', () => {
+      const items = [makeItem('A', older, 1), makeItem('B', newer, 2)];
+      const comments = [makeComment('C1', 'A'), makeComment('C2', 'B')];
+      const res = filterItemsForPush(items, comments, lastPush);
+      expect(res.filteredComments.map(c => c.id)).toEqual(['C2']);
+    });
+
+    it('excludes comments for deleted items', () => {
+      const items = [makeItem('A', newer, 1, 'deleted')];
+      const comments = [makeComment('C1', 'A')];
+      const res = filterItemsForPush(items, comments, lastPush);
+      expect(res.filteredComments.length).toBe(0);
+    });
+
+    it('handles comments with no matching item', () => {
+      const items = [makeItem('A', newer, 1)];
+      const comments = [makeComment('C1', 'A'), makeComment('C2', 'Z')]; // Z doesn't exist
+      const res = filterItemsForPush(items, comments, lastPush);
+      // Only C1 matches item A
+      expect(res.filteredComments.map(c => c.id)).toEqual(['C1']);
+    });
+
+    it('returns empty comments when all items are filtered out', () => {
+      const items = [makeItem('A', older, 1)];
+      const comments = [makeComment('C1', 'A')];
+      const res = filterItemsForPush(items, comments, lastPush);
+      expect(res.filteredItems.length).toBe(0);
+      expect(res.filteredComments.length).toBe(0);
+    });
   });
 
-  it('excludes deleted items from candidates', () => {
-    // Use no timestamp so filtering only removes deleted items
-    const items = [makeItem('A', baseTime, 1), makeItem('B', baseTime, undefined, 'deleted')];
-    const comments = [makeComment('C1', 'A'), makeComment('C2', 'B')];
-    const res = filterItemsForPush(items, comments, null);
-    expect(res.totalCandidates).toBe(1);
-    expect(res.filteredItems.map(i => i.id)).toEqual(['A']);
-    expect(res.filteredComments.map(c => c.workItemId)).toEqual(['A']);
+  // -------------------------------------------------------------------
+  // Mixed state scenarios
+  // -------------------------------------------------------------------
+  describe('mixed item states', () => {
+    const lastPush = new Date('2025-01-02T00:00:00.000Z').toISOString();
+    const newer = new Date('2025-01-03T00:00:00.000Z').toISOString();
+    const older = new Date('2025-01-01T00:00:00.000Z').toISOString();
+
+    it('correctly handles mix of new, changed, unchanged, and deleted items', () => {
+      const items = [
+        makeItem('new-item', older),               // no githubIssueNumber -> included
+        makeItem('changed', newer, 10),             // newer -> included
+        makeItem('unchanged', older, 20),            // older + has issue -> skipped
+        makeItem('deleted-item', newer, 30, 'deleted'), // deleted -> excluded
+      ];
+      const comments = [
+        makeComment('C1', 'new-item'),
+        makeComment('C2', 'changed'),
+        makeComment('C3', 'unchanged'),
+        makeComment('C4', 'deleted-item'),
+      ];
+      const res = filterItemsForPush(items, comments, lastPush);
+      expect(res.filteredItems.map(i => i.id).sort()).toEqual(['changed', 'new-item']);
+      expect(res.filteredComments.map(c => c.workItemId).sort()).toEqual(['changed', 'new-item']);
+      expect(res.totalCandidates).toBe(3); // excludes deleted
+      expect(res.skippedCount).toBe(1); // only 'unchanged'
+    });
   });
 
-  it('read/write timestamp file roundtrip fallback', () => {
-    // Ensure we can write and read a timestamp via file fallback
-    const now = new Date().toISOString();
-    // write to file (no DB provided)
-    writeLastPushTimestamp(now as string, undefined as any);
-    const read = readLastPushTimestamp(undefined as any);
-    expect(read).toBeTruthy();
-    expect(new Date(read as string).getTime()).toBeGreaterThan(0);
+  // -------------------------------------------------------------------
+  // Edge cases
+  // -------------------------------------------------------------------
+  describe('edge cases', () => {
+    it('handles empty items array', () => {
+      const res = filterItemsForPush([], [], null);
+      expect(res.filteredItems.length).toBe(0);
+      expect(res.filteredComments.length).toBe(0);
+      expect(res.totalCandidates).toBe(0);
+      expect(res.skippedCount).toBe(0);
+    });
+
+    it('handles empty items with valid timestamp', () => {
+      const lastPush = new Date('2025-01-02T00:00:00.000Z').toISOString();
+      const res = filterItemsForPush([], [], lastPush);
+      expect(res.filteredItems.length).toBe(0);
+      expect(res.skippedCount).toBe(0);
+    });
+
+    it('handles items with empty comments array', () => {
+      const lastPush = new Date('2025-01-02T00:00:00.000Z').toISOString();
+      const newer = new Date('2025-01-03T00:00:00.000Z').toISOString();
+      const items = [makeItem('A', newer, 1)];
+      const res = filterItemsForPush(items, [], lastPush);
+      expect(res.filteredItems.length).toBe(1);
+      expect(res.filteredComments.length).toBe(0);
+    });
+
+    it('processes all non-deleted items when lastPush is null regardless of githubIssueNumber', () => {
+      const items = [
+        makeItem('A', baseTime, 1),
+        makeItem('B', baseTime, 2),
+        makeItem('C', baseTime),
+      ];
+      const res = filterItemsForPush(items, [], null);
+      expect(res.filteredItems.length).toBe(3);
+      expect(res.skippedCount).toBe(0);
+    });
+
+    it('counts totalCandidates correctly with only deleted items', () => {
+      const items = [
+        makeItem('A', baseTime, 1, 'deleted'),
+        makeItem('B', baseTime, 2, 'deleted'),
+      ];
+      const res = filterItemsForPush(items, [], null);
+      expect(res.totalCandidates).toBe(0);
+      expect(res.filteredItems.length).toBe(0);
+      expect(res.skippedCount).toBe(0);
+    });
+  });
+
+  // -------------------------------------------------------------------
+  // AC3: Logging stats (verified by inspecting return values)
+  // -------------------------------------------------------------------
+  describe('filter stats for logging', () => {
+    it('provides correct stats for mixed filtering', () => {
+      const lastPush = new Date('2025-01-02T00:00:00.000Z').toISOString();
+      const newer = new Date('2025-01-03T00:00:00.000Z').toISOString();
+      const older = new Date('2025-01-01T00:00:00.000Z').toISOString();
+      const items = [
+        makeItem('A', older, 1),   // skipped
+        makeItem('B', older, 2),   // skipped
+        makeItem('C', newer, 3),   // included
+        makeItem('D', older),      // new item, included
+        makeItem('E', newer, 5),   // included
+        makeItem('F', older, 6, 'deleted'), // excluded from candidates
+      ];
+      const res = filterItemsForPush(items, [], lastPush);
+      // totalCandidates = 5 (F excluded as deleted)
+      // filtered = C, D, E => 3
+      // skipped = A, B => 2
+      expect(res.totalCandidates).toBe(5);
+      expect(res.filteredItems.length).toBe(3);
+      expect(res.skippedCount).toBe(2);
+      // Verify the log message can be constructed from these values:
+      // "Processing 3 of 5 items (2 skipped, unchanged since last push)"
+    });
+  });
+
+  // -------------------------------------------------------------------
+  // Timestamp read/write
+  // -------------------------------------------------------------------
+  describe('timestamp read/write', () => {
+    it('read/write timestamp file roundtrip fallback', () => {
+      const now = new Date().toISOString();
+      writeLastPushTimestamp(now as string, undefined as any);
+      const read = readLastPushTimestamp(undefined as any);
+      expect(read).toBeTruthy();
+      expect(new Date(read as string).getTime()).toBeGreaterThan(0);
+    });
+
+    it('readLastPushTimestamp returns null with no DB and no file', () => {
+      // When no DB metadata and file does not exist, should return null
+      // This test relies on the file not existing yet or the fallback logic
+      const read = readLastPushTimestamp(undefined as any);
+      // May or may not be null depending on prior test writing a file,
+      // but should not throw
+      expect(read === null || typeof read === 'string').toBe(true);
+    });
+
+    it('readLastPushTimestamp uses DB metadata when available', () => {
+      const ts = '2025-06-15T12:00:00.000Z';
+      const fakeDb = {
+        getMetadata: (key: string) => key === 'githubLastPush' ? ts : null,
+      };
+      const read = readLastPushTimestamp(fakeDb);
+      expect(read).toBe(ts);
+    });
+
+    it('readLastPushTimestamp falls back to file when DB returns null', () => {
+      const fakeDb = {
+        getMetadata: () => null,
+      };
+      // Should fall through to file-based read without throwing
+      const read = readLastPushTimestamp(fakeDb);
+      expect(read === null || typeof read === 'string').toBe(true);
+    });
+
+    it('readLastPushTimestamp falls back to file when DB throws', () => {
+      const fakeDb = {
+        getMetadata: () => { throw new Error('DB error'); },
+      };
+      // Should not throw, should fall through to file-based read
+      const read = readLastPushTimestamp(fakeDb);
+      expect(read === null || typeof read === 'string').toBe(true);
+    });
   });
 });


### PR DESCRIPTION
## Summary

Expands unit test coverage for the `filterItemsForPush` pre-filter logic in `src/github-pre-filter.ts` to comprehensively verify all acceptance criteria for the Pre-filter changed items feature (WL-0MLWTYXAD01EG7QB).

## Work Done

The existing 4 test cases have been expanded to **30 test cases** organized into logical groups matching each acceptance criterion:

| Group | Tests | Acceptance Criteria |
|-------|-------|-------------------|
| First run / no timestamp | 3 | AC4: null, empty, invalid timestamps all process all items |
| Pre-filter with valid timestamp | 7 | AC1/AC5: updatedAt > lastPush included; <= skipped; no issueNumber included |
| Deleted item exclusion | 3 | AC2: deleted items excluded from candidates and counts |
| Comment filtering | 5 | AC6: comments matched to filtered items only |
| Mixed item states | 1 | Integration: new + changed + unchanged + deleted in single pass |
| Edge cases | 5 | Empty arrays, all-deleted, invalid dates |
| Filter stats for logging | 1 | AC3: totalCandidates, skippedCount values correct |
| Timestamp read/write | 5 | DB metadata preference, file fallback, error resilience |

## How to Test

```bash
npm test -- tests/github-pre-filter.test.ts
```

All 635 tests pass across the full suite with a clean build.

## Review Focus

- Verify test cases adequately cover the boundary conditions (equal timestamps, invalid dates)
- Verify the deleted item exclusion tests match the intended behavior (Feature 3 handles deleted sync separately)
- Verify comment filtering edge cases (orphaned comments, comments for filtered-out items)

## References

- Work item: WL-0MLWTYXAD01EG7QB (Pre-filter changed items)
- Parent: WL-0MLWQZTR20CICVO7 (wl gh push should only push items that have been changed since the last time it was run)
- Dependency: WL-0MLWTYH2H034D79E (Last-push timestamp storage) - completed