### PR TITLE
Allow deleted items with githubIssueNumber through pre-filter

### DIFF
--- a/src/github-pre-filter.ts
+++ b/src/github-pre-filter.ts
@@ -6,7 +6,7 @@ import { resolveWorklogDir } from './worklog-paths.js';
 export interface PreFilterResult {
   filteredItems: WorkItem[];
   filteredComments: Comment[];
-  totalCandidates: number; // items considered (excluding deleted)
+  totalCandidates: number; // items considered (excluding deleted items without githubIssueNumber)
   skippedCount: number;
 }
 
@@ -73,9 +73,17 @@ function isValidIso(iso?: string | null): boolean {
 }
 
 export function filterItemsForPush(items: WorkItem[], comments: Comment[], lastPushTimestamp: string | null): PreFilterResult {
-  // Exclude deleted items entirely from consideration
-  const candidates = items.filter(i => i.status !== 'deleted');
-  // If no timestamp recorded, return all candidates and all comments
+  // Exclude deleted items that have no githubIssueNumber (they can never be
+  // closed on GitHub). Deleted items WITH a githubIssueNumber are kept so
+  // their corresponding GitHub issues can be closed.
+  const candidates = items.filter(i => {
+    if (i.status === 'deleted') {
+      return i.githubIssueNumber != null;
+    }
+    return true;
+  });
+
+  // If no timestamp recorded (first run / force mode), return all candidates
   if (!isValidIso(lastPushTimestamp)) {
     return {
       filteredItems: candidates,

--- a/tests/github-pre-filter.test.ts
+++ b/tests/github-pre-filter.test.ts
@@ -136,10 +136,11 @@ describe('github pre-filter', () => {
   });
 
   // -------------------------------------------------------------------
-  // AC2: Items with status === 'deleted' are excluded from this filter
+  // AC: Deleted items without githubIssueNumber are excluded;
+  //     deleted items WITH githubIssueNumber are included as candidates
   // -------------------------------------------------------------------
-  describe('deleted item exclusion', () => {
-    it('excludes deleted items from candidates', () => {
+  describe('deleted item handling', () => {
+    it('excludes deleted items without githubIssueNumber', () => {
       const items = [makeItem('A', baseTime, 1), makeItem('B', baseTime, undefined, 'deleted')];
       const comments = [makeComment('C1', 'A'), makeComment('C2', 'B')];
       const res = filterItemsForPush(items, comments, null);
@@ -148,24 +149,61 @@ describe('github pre-filter', () => {
       expect(res.filteredComments.map(c => c.workItemId)).toEqual(['A']);
     });
 
-    it('excludes deleted items even when they have a githubIssueNumber', () => {
+    it('includes deleted items with githubIssueNumber when updatedAt > lastPush', () => {
       const lastPush = new Date('2025-01-02T00:00:00.000Z').toISOString();
       const newer = new Date('2025-01-03T00:00:00.000Z').toISOString();
       const items = [makeItem('A', newer, 10, 'deleted')];
       const res = filterItemsForPush(items, [], lastPush);
-      expect(res.filteredItems.length).toBe(0);
-      expect(res.totalCandidates).toBe(0);
+      expect(res.filteredItems.map(i => i.id)).toEqual(['A']);
+      expect(res.totalCandidates).toBe(1);
       expect(res.skippedCount).toBe(0);
     });
 
-    it('excludes deleted items from totalCandidates count', () => {
+    it('excludes deleted items with githubIssueNumber when updatedAt <= lastPush', () => {
+      const lastPush = new Date('2025-01-02T00:00:00.000Z').toISOString();
+      const older = new Date('2025-01-01T00:00:00.000Z').toISOString();
+      const items = [makeItem('A', older, 10, 'deleted')];
+      const res = filterItemsForPush(items, [], lastPush);
+      expect(res.filteredItems.length).toBe(0);
+      expect(res.totalCandidates).toBe(1);
+      expect(res.skippedCount).toBe(1);
+    });
+
+    it('includes all deleted items with githubIssueNumber when lastPush is null (force/first-run)', () => {
       const items = [
-        makeItem('A', baseTime, 1),
-        makeItem('B', baseTime, 2, 'deleted'),
-        makeItem('C', baseTime, 3, 'deleted'),
+        makeItem('A', baseTime, 10, 'deleted'),
+        makeItem('B', baseTime, 20, 'deleted'),
+        makeItem('C', baseTime, undefined, 'deleted'), // no githubIssueNumber -> excluded
       ];
       const res = filterItemsForPush(items, [], null);
-      expect(res.totalCandidates).toBe(1);
+      expect(res.filteredItems.map(i => i.id).sort()).toEqual(['A', 'B']);
+      expect(res.totalCandidates).toBe(2);
+    });
+
+    it('includes totalCandidates count for eligible deleted items', () => {
+      const items = [
+        makeItem('A', baseTime, 1),
+        makeItem('B', baseTime, 2, 'deleted'),   // has githubIssueNumber -> candidate
+        makeItem('C', baseTime, 3, 'deleted'),   // has githubIssueNumber -> candidate
+      ];
+      const res = filterItemsForPush(items, [], null);
+      expect(res.totalCandidates).toBe(3);
+    });
+
+    it('includes comments for eligible deleted items', () => {
+      const lastPush = new Date('2025-01-02T00:00:00.000Z').toISOString();
+      const newer = new Date('2025-01-03T00:00:00.000Z').toISOString();
+      const items = [makeItem('A', newer, 10, 'deleted')];
+      const comments = [makeComment('C1', 'A')];
+      const res = filterItemsForPush(items, comments, lastPush);
+      expect(res.filteredComments.map(c => c.workItemId)).toEqual(['A']);
+    });
+
+    it('excludes comments for deleted items without githubIssueNumber', () => {
+      const items = [makeItem('A', baseTime, undefined, 'deleted')];
+      const comments = [makeComment('C1', 'A')];
+      const res = filterItemsForPush(items, comments, null);
+      expect(res.filteredComments.length).toBe(0);
     });
   });
 
@@ -192,8 +230,8 @@ describe('github pre-filter', () => {
       expect(res.filteredComments.map(c => c.id)).toEqual(['C2']);
     });
 
-    it('excludes comments for deleted items', () => {
-      const items = [makeItem('A', newer, 1, 'deleted')];
+    it('excludes comments for deleted items without githubIssueNumber', () => {
+      const items = [makeItem('A', newer, undefined, 'deleted')];
       const comments = [makeComment('C1', 'A')];
       const res = filterItemsForPush(items, comments, lastPush);
       expect(res.filteredComments.length).toBe(0);
@@ -229,18 +267,20 @@ describe('github pre-filter', () => {
         makeItem('new-item', older),               // no githubIssueNumber -> included
         makeItem('changed', newer, 10),             // newer -> included
         makeItem('unchanged', older, 20),            // older + has issue -> skipped
-        makeItem('deleted-item', newer, 30, 'deleted'), // deleted -> excluded
+        makeItem('deleted-with-issue', newer, 30, 'deleted'), // deleted + has issue + newer -> included
+        makeItem('deleted-no-issue', newer, undefined, 'deleted'), // deleted + no issue -> excluded
       ];
       const comments = [
         makeComment('C1', 'new-item'),
         makeComment('C2', 'changed'),
         makeComment('C3', 'unchanged'),
-        makeComment('C4', 'deleted-item'),
+        makeComment('C4', 'deleted-with-issue'),
+        makeComment('C5', 'deleted-no-issue'),
       ];
       const res = filterItemsForPush(items, comments, lastPush);
-      expect(res.filteredItems.map(i => i.id).sort()).toEqual(['changed', 'new-item']);
-      expect(res.filteredComments.map(c => c.workItemId).sort()).toEqual(['changed', 'new-item']);
-      expect(res.totalCandidates).toBe(3); // excludes deleted
+      expect(res.filteredItems.map(i => i.id).sort()).toEqual(['changed', 'deleted-with-issue', 'new-item']);
+      expect(res.filteredComments.map(c => c.workItemId).sort()).toEqual(['changed', 'deleted-with-issue', 'new-item']);
+      expect(res.totalCandidates).toBe(4); // excludes deleted-no-issue only
       expect(res.skippedCount).toBe(1); // only 'unchanged'
     });
   });
@@ -286,8 +326,19 @@ describe('github pre-filter', () => {
 
     it('counts totalCandidates correctly with only deleted items', () => {
       const items = [
-        makeItem('A', baseTime, 1, 'deleted'),
-        makeItem('B', baseTime, 2, 'deleted'),
+        makeItem('A', baseTime, 1, 'deleted'),    // has githubIssueNumber -> candidate
+        makeItem('B', baseTime, 2, 'deleted'),    // has githubIssueNumber -> candidate
+      ];
+      const res = filterItemsForPush(items, [], null);
+      expect(res.totalCandidates).toBe(2);
+      expect(res.filteredItems.length).toBe(2);
+      expect(res.skippedCount).toBe(0);
+    });
+
+    it('counts totalCandidates as zero with only deleted items without githubIssueNumber', () => {
+      const items = [
+        makeItem('A', baseTime, undefined, 'deleted'),
+        makeItem('B', baseTime, undefined, 'deleted'),
       ];
       const res = filterItemsForPush(items, [], null);
       expect(res.totalCandidates).toBe(0);
@@ -310,15 +361,16 @@ describe('github pre-filter', () => {
         makeItem('C', newer, 3),   // included
         makeItem('D', older),      // new item, included
         makeItem('E', newer, 5),   // included
-        makeItem('F', older, 6, 'deleted'), // excluded from candidates
+        makeItem('F', older, 6, 'deleted'), // deleted + has issue -> candidate, but older -> skipped
+        makeItem('G', older, undefined, 'deleted'), // deleted + no issue -> excluded from candidates
       ];
       const res = filterItemsForPush(items, [], lastPush);
-      // totalCandidates = 5 (F excluded as deleted)
+      // totalCandidates = 6 (G excluded as deleted without githubIssueNumber)
       // filtered = C, D, E => 3
-      // skipped = A, B => 2
-      expect(res.totalCandidates).toBe(5);
+      // skipped = A, B, F => 3
+      expect(res.totalCandidates).toBe(6);
       expect(res.filteredItems.length).toBe(3);
-      expect(res.skippedCount).toBe(2);
+      expect(res.skippedCount).toBe(3);
       // Verify the log message can be constructed from these values:
       // "Processing 3 of 5 items (2 skipped, unchanged since last push)"
     });


### PR DESCRIPTION
## Summary

Modifies `filterItemsForPush()` in `src/github-pre-filter.ts` to stop blanket-excluding deleted items. Deleted items with a `githubIssueNumber` now pass through the pre-filter so their corresponding GitHub issues can be closed during `wl github push`.

**Work item:** WL-0MLXLSCBQ0NAH3RR (child of WL-0MLWTZBZN1BMM5BN - Sync locally-deleted items)

## Changes

- **`src/github-pre-filter.ts`**: Replaced `items.filter(i => i.status !== 'deleted')` with a selective filter that keeps deleted items having a `githubIssueNumber` as candidates. These follow the same timestamp filtering as non-deleted items. Updated the `PreFilterResult.totalCandidates` comment to reflect the new semantics.

- **`tests/github-pre-filter.test.ts`**: Updated existing tests and added new tests covering:
  - Deleted items with `githubIssueNumber` and `updatedAt > lastPush` are included
  - Deleted items with `githubIssueNumber` and `updatedAt <= lastPush` are excluded (normal mode)
  - All deleted items with `githubIssueNumber` are included when `lastPushTimestamp` is null (force/first-run)
  - Deleted items without `githubIssueNumber` remain excluded regardless
  - Comments for eligible deleted items are included
  - `totalCandidates` and `skippedCount` correctly account for eligible deleted items

## How to test

```bash
npx vitest run tests/github-pre-filter.test.ts
```

All 640 tests across 73 test files pass.

## Review focus

- The filter logic change at `src/github-pre-filter.ts:79-84` -- verify the `githubIssueNumber != null` guard correctly identifies closeable deleted items
- Test coverage for the timestamp-based filtering of deleted items (especially the `<= lastPush` exclusion case)
- Verify no behavioral changes for non-deleted items