### PR TITLE
Add closed count to GithubSyncResult and sync output

### DIFF
--- a/src/commands/github.ts
+++ b/src/commands/github.ts
@@ -165,7 +165,7 @@ export default function register(ctx: PluginContext): void {
         }
 
         logLine(`Repo ${githubConfig.repo}`);
-        logLine(`Push summary created=${result.created} updated=${result.updated} skipped=${result.skipped}`);
+        logLine(`Push summary created=${result.created} updated=${result.updated} closed=${result.closed} skipped=${result.skipped}`);
         if ((result.commentsCreated || 0) > 0 || (result.commentsUpdated || 0) > 0) {
           logLine(`Comment summary created=${result.commentsCreated || 0} updated=${result.commentsUpdated || 0}`);
         }
@@ -185,6 +185,7 @@ export default function register(ctx: PluginContext): void {
           console.log(`GitHub sync complete (${githubConfig.repo})`);
           console.log(`  Created: ${result.created}`);
           console.log(`  Updated: ${result.updated}`);
+          console.log(`  Closed: ${result.closed}`);
           console.log(`  Skipped: ${result.skipped}`);
           if (options.force) console.log('  Note: --force was used; pre-filter was bypassed');
           if ((result.commentsCreated || 0) > 0 || (result.commentsUpdated || 0) > 0) {

--- a/src/github-sync.ts
+++ b/src/github-sync.ts
@@ -40,6 +40,7 @@ import { mergeWorkItems } from './sync.js';
 export interface GithubSyncResult {
   updated: number;
   created: number;
+  closed: number;
   skipped: number;
   errors: string[];
   commentsCreated?: number;
@@ -95,7 +96,7 @@ export async function upsertIssuesFromWorkItems(
   }
 
   const updatedItems: WorkItem[] = [...items];
-  const result: GithubSyncResult = { updated: 0, created: 0, skipped: 0, errors: [] };
+  const result: GithubSyncResult = { updated: 0, created: 0, closed: 0, skipped: 0, errors: [] };
   const updatedById = new Map<string, WorkItem>();
   let processed = 0;
   let skippedUpdates = 0;
@@ -276,7 +277,11 @@ export async function upsertIssuesFromWorkItems(
         if (item.githubIssueNumber) {
           increment('api.issue.update');
           issue = await updateGithubIssueAsync(config, item.githubIssueNumber, payload);
-          result.updated += 1;
+          if (item.status === 'deleted') {
+            result.closed += 1;
+          } else {
+            result.updated += 1;
+          }
         } else {
           increment('api.issue.create');
           issue = await createGithubIssueAsync(config, {

--- a/tests/github-sync-deleted.test.ts
+++ b/tests/github-sync-deleted.test.ts
@@ -128,8 +128,9 @@ describe('github-sync deleted item handling', () => {
     );
     expect(createGithubIssueAsync).not.toHaveBeenCalled();
 
-    // Should count as updated, not skipped
-    expect(result.updated).toBeGreaterThanOrEqual(1);
+    // Should count as closed, not updated
+    expect(result.closed).toBe(1);
+    expect(result.updated).toBe(0);
     expect(result.created).toBe(0);
   });
 
@@ -219,9 +220,12 @@ describe('github-sync deleted item handling', () => {
       dummyConfig as any,
     );
 
-    // Both active and deleted-with-issue should be updated
+    // activeItem should be updated, deletedWithIssue should be closed
     expect(updateGithubIssueAsync).toHaveBeenCalledTimes(2);
     expect(createGithubIssueAsync).not.toHaveBeenCalled();
+
+    expect(result.updated).toBe(1);
+    expect(result.closed).toBe(1);
 
     // deleted-without-issue is excluded by the filter (items.length - issueItems.length = 1)
     expect(result.skipped).toBeGreaterThanOrEqual(1);
@@ -301,7 +305,8 @@ describe('github-sync deleted item handling', () => {
       expect.objectContaining({ state: 'closed' }),
     );
     expect(result.errors).toHaveLength(0);
-    expect(result.updated).toBe(1);
+    expect(result.closed).toBe(1);
+    expect(result.updated).toBe(0);
   });
 
   // AC5: Force mode — all deleted items with githubIssueNumber are processed at sync level.
@@ -348,7 +353,8 @@ describe('github-sync deleted item handling', () => {
     );
     // No issues should be created
     expect(createGithubIssueAsync).not.toHaveBeenCalled();
-    expect(result.updated).toBe(2);
+    expect(result.closed).toBe(2);
+    expect(result.updated).toBe(0);
     expect(result.created).toBe(0);
     // deletedNoIssue is excluded by the filter
     expect(result.skipped).toBeGreaterThanOrEqual(1);
@@ -400,7 +406,7 @@ describe('github-sync deleted item handling', () => {
     expect(createGithubIssueAsync).toHaveBeenCalledTimes(1);
     expect(result.created).toBe(1);
 
-    // changedItem -> updated, deletedWithIssue -> updated (state: closed)
+    // changedItem -> updated, deletedWithIssue -> closed (state: closed)
     expect(updateGithubIssueAsync).toHaveBeenCalledTimes(2);
     expect(updateGithubIssueAsync).toHaveBeenCalledWith(
       expect.anything(),
@@ -412,7 +418,8 @@ describe('github-sync deleted item handling', () => {
       502,
       expect.objectContaining({ state: 'closed' }),
     );
-    expect(result.updated).toBe(2);
+    expect(result.updated).toBe(1);
+    expect(result.closed).toBe(1);
 
     // unchangedItem skipped by timestamp check, deletedNoIssue excluded by filter
     expect(result.skipped).toBe(2);


### PR DESCRIPTION
## Summary

Adds a distinct `closed` count to `GithubSyncResult` so that deleted items whose GitHub issues are closed during `wl github push` are reported separately from generic updates. This satisfies success criterion 8 of the parent work item Sync locally-deleted items (WL-0MLWTZBZN1BMM5BN), which requires that deleted items are reported in the sync output with action "closed".

## Changes

- **`src/github-sync.ts`**: Added `closed: number` to the `GithubSyncResult` interface and initialization. In the upsert update path, deleted items now increment `result.closed` instead of `result.updated`.
- **`src/commands/github.ts`**: Added `Closed: N` line to CLI text output (between Updated and Skipped). Added `closed=N` to the push log line. JSON output automatically includes the new field via the existing `...result` spread.
- **`tests/github-sync-deleted.test.ts`**: Updated assertions across 4 test cases to verify that deleted items increment `result.closed` (not `result.updated`), including the mixed-set test that verifies correct separate counts.

## How to test

1. Run `npx vitest run tests/github-sync-deleted.test.ts` to verify deleted-item count assertions
2. Run `npx vitest run` to verify no regressions (650 tests, 74 files)
3. To see the output change in practice: delete a local work item that has a `githubIssueNumber`, then run `wl github push` -- the CLI should show `Closed: 1` as a separate line

## Review focus

- The conditional branching at `src/github-sync.ts:279-283` -- confirm that only `item.status === 'deleted'` increments `closed`, all other statuses continue to increment `updated`
- The `result.skipped` computation at line 406 is unchanged and should remain correct

## Work items

- WL-0MLYEW3VB1GX4M8O (this task)
- WL-0MLWTZBZN1BMM5BN (parent: Sync locally-deleted items)