### PR TITLE
WL-0MLWTZOBU0ZW7P0X: Add --all flag to wl github push

### DIFF
--- a/src/commands/github.ts
+++ b/src/commands/github.ts
@@ -40,7 +40,8 @@ export default function register(ctx: PluginContext): void {
     .description('Mirror work items to GitHub Issues')
     .option('--repo <owner/name>', 'GitHub repo (owner/name)')
     .option('--label-prefix <prefix>', 'Label prefix for Worklog labels (default: wl:)')
-    .option('--force', 'Bypass pre-filter and process all items')
+    .option('--all', 'Force a full push of all items, ignoring the last-push timestamp')
+    .option('--force', 'Deprecated alias for --all (bypass pre-filter and process all items)', false)
     .option('--no-update-timestamp', 'Do not write last-push timestamp after push')
     .option('--prefix <prefix>', 'Override the default prefix')
     .action(async (options) => {
@@ -95,10 +96,11 @@ export default function register(ctx: PluginContext): void {
         // Pass DB to timestamp helpers when available so they may use metadata
         const dbForMetadata = typeof db.getAll === 'function' && typeof (db as any).store === 'object' ? (db as any).store : undefined;
 
-        if (options.force) {
-          // Bypass pre-filter when --force specified
-          if (!isJsonMode) console.log('Force push: processing all items (pre-filter bypassed)');
-          logLine('github push: force mode enabled - processing all items');
+        const forceAll = Boolean(options.all) || Boolean(options.force);
+        if (forceAll) {
+          // Bypass pre-filter when --all (or deprecated --force) specified
+          if (!isJsonMode) console.log(`Full push (--all): processing all ${items.length} items`);
+          logLine('github push: --all mode enabled - processing all items');
         } else {
           // Pre-filter items to only those changed since last push or never pushed
           try {
@@ -157,9 +159,9 @@ export default function register(ctx: PluginContext): void {
             if (!isJsonMode) console.log('Note: last-push timestamp was not updated (--no-update-timestamp)');
           } else {
             writeLastPushTimestamp(pushStartTimestamp, dbForMetadata);
-            if (options.force) {
-              // In force mode still update timestamp but record that it was a forced push
-              logLine(`github push: force push completed - lastPush updated to ${pushStartTimestamp}`);
+            if (forceAll) {
+              // In --all mode still update timestamp but record that it was a full push
+              logLine(`github push: full push (--all) completed - lastPush updated to ${pushStartTimestamp}`);
             } else {
               logLine(`github push: lastPush updated from ${lastPush ?? 'none'} to ${pushStartTimestamp}`);
             }
@@ -192,7 +194,7 @@ export default function register(ctx: PluginContext): void {
           console.log(`  Updated: ${result.updated}`);
           console.log(`  Closed: ${result.closed}`);
           console.log(`  Skipped: ${result.skipped}`);
-          if (options.force) console.log('  Note: --force was used; pre-filter was bypassed');
+          if (forceAll) console.log('  Note: --all was used; pre-filter was bypassed');
           if ((result.commentsCreated || 0) > 0 || (result.commentsUpdated || 0) > 0) {
             console.log(`  Comments created: ${result.commentsCreated || 0}`);
             console.log(`  Comments updated: ${result.commentsUpdated || 0}`);

--- a/tests/cli/github-push-force.test.ts
+++ b/tests/cli/github-push-force.test.ts
@@ -3,8 +3,8 @@ import * as fs from 'fs';
 import * as path from 'path';
 import { enterTempDir, leaveTempDir, writeConfig, writeInitSemaphore, seedWorkItems, execAsync, cliPath } from './cli-helpers.js';
 
-describe('github push --force timestamp behavior', () => {
-  it('when --force is used timestamp file is still written by default', async () => {
+describe('github push --all flag', () => {
+  it('--all processes all items and writes timestamp file', async () => {
     const state = enterTempDir();
     try {
       writeConfig(state.tempDir);
@@ -14,12 +14,94 @@ describe('github push --force timestamp behavior', () => {
       const timestampPath = path.join(state.tempDir, '.worklog', 'github-last-push');
       if (fs.existsSync(timestampPath)) fs.unlinkSync(timestampPath);
 
-      await execAsync(`tsx ${cliPath} github push --repo owner/name --force`, { cwd: state.tempDir });
+      const { stdout } = await execAsync(`tsx ${cliPath} github push --repo owner/name --all`, { cwd: state.tempDir });
 
+      // Timestamp file should still be written
       expect(fs.existsSync(timestampPath)).toBe(true);
       const content = fs.readFileSync(timestampPath, 'utf-8').trim();
       expect(() => new Date(content)).not.toThrow();
       expect(isNaN(new Date(content).getTime())).toBe(false);
+
+      // Output should indicate full push mode
+      expect(stdout).toContain('Full push (--all)');
+    } finally {
+      leaveTempDir(state);
+    }
+  });
+
+  it('--all output indicates that pre-filter was bypassed', async () => {
+    const state = enterTempDir();
+    try {
+      writeConfig(state.tempDir);
+      writeInitSemaphore(state.tempDir);
+      seedWorkItems(state.tempDir, []);
+
+      const { stdout } = await execAsync(`tsx ${cliPath} github push --repo owner/name --all`, { cwd: state.tempDir });
+
+      expect(stdout).toContain('--all was used; pre-filter was bypassed');
+    } finally {
+      leaveTempDir(state);
+    }
+  });
+
+  it('--all with seeded items shows item count in output', async () => {
+    const state = enterTempDir();
+    try {
+      writeConfig(state.tempDir);
+      writeInitSemaphore(state.tempDir);
+      seedWorkItems(state.tempDir, [
+        { id: 'WL-TEST1', title: 'Item 1', status: 'open' as any, priority: 'medium' as any },
+        { id: 'WL-TEST2', title: 'Item 2', status: 'open' as any, priority: 'medium' as any },
+      ]);
+
+      const { stdout } = await execAsync(`tsx ${cliPath} github push --repo owner/name --all`, { cwd: state.tempDir });
+
+      // Should indicate "processing all N items"
+      expect(stdout).toMatch(/Full push \(--all\): processing all \d+ items/);
+    } finally {
+      leaveTempDir(state);
+    }
+  });
+
+  it('without --all, pre-filter is applied', async () => {
+    const state = enterTempDir();
+    try {
+      writeConfig(state.tempDir);
+      writeInitSemaphore(state.tempDir);
+      seedWorkItems(state.tempDir, []);
+
+      const { stdout } = await execAsync(`tsx ${cliPath} github push --repo owner/name`, { cwd: state.tempDir });
+
+      // Should NOT contain the --all message
+      expect(stdout).not.toContain('Full push (--all)');
+      expect(stdout).not.toContain('--all was used');
+    } finally {
+      leaveTempDir(state);
+    }
+  });
+});
+
+describe('github push --force (deprecated alias)', () => {
+  it('--force still works as backward-compatible alias for --all', async () => {
+    const state = enterTempDir();
+    try {
+      writeConfig(state.tempDir);
+      writeInitSemaphore(state.tempDir);
+      seedWorkItems(state.tempDir, []);
+
+      const timestampPath = path.join(state.tempDir, '.worklog', 'github-last-push');
+      if (fs.existsSync(timestampPath)) fs.unlinkSync(timestampPath);
+
+      const { stdout } = await execAsync(`tsx ${cliPath} github push --repo owner/name --force`, { cwd: state.tempDir });
+
+      // Timestamp file should still be written
+      expect(fs.existsSync(timestampPath)).toBe(true);
+      const content = fs.readFileSync(timestampPath, 'utf-8').trim();
+      expect(() => new Date(content)).not.toThrow();
+      expect(isNaN(new Date(content).getTime())).toBe(false);
+
+      // Output should indicate full push mode (same as --all)
+      expect(stdout).toContain('Full push (--all)');
     } finally {
       leaveTempDir(state);
     }


### PR DESCRIPTION
## Summary

- Add `--all` CLI flag to `wl github push` that bypasses the pre-filter and processes all items regardless of the last-push timestamp
- Retain `--force` as a deprecated backward-compatible alias for `--all`
- Output clearly indicates full push mode: `Full push (--all): processing all N items`

## Changes

- `src/commands/github.ts`: Added `--all` option, kept `--force` as deprecated alias, unified handler logic via `forceAll` variable, updated all output/log messages
- `tests/cli/github-push-force.test.ts`: Expanded from 1 test to 5 tests covering `--all` behavior, item count output, pre-filter bypass verification, negative case (without `--all`), and `--force` backward compatibility

## Acceptance Criteria Met

- `wl github push --all` processes every item regardless of the last-push timestamp
- Deleted items with `githubIssueNumber` are still included when `--all` is used
- The `--all` flag is documented in `wl github push --help` output
- When `--all` is used, the output indicates that a full push was performed
- Without `--all`, items unchanged since last push are skipped (pre-filter applies)
- The last-push timestamp is still updated after a successful full push

## Work Item

WL-0MLWTZOBU0ZW7P0X (child of WL-0MLWQZTR20CICVO7)