### PR TITLE
WL-0MLWU03N203Z3QWW: Per-item sync output with URLs

### DIFF
--- a/src/commands/github.ts
+++ b/src/commands/github.ts
@@ -4,7 +4,7 @@
 
 import type { PluginContext } from '../plugin-types.js';
 import { getRepoFromGitRemote, normalizeGithubLabelPrefix } from '../github.js';
-import { upsertIssuesFromWorkItems, importIssuesToWorkItems, GithubProgress } from '../github-sync.js';
+import { upsertIssuesFromWorkItems, importIssuesToWorkItems, GithubProgress, SyncedItem, SyncErrorItem } from '../github-sync.js';
 import { loadConfig } from '../config.js';
 import { displayConflictDetails } from './helpers.js';
 import { createLogFileWriter, getWorklogLogPath, logConflictDetails } from '../logging.js';
@@ -187,7 +187,24 @@ export default function register(ctx: PluginContext): void {
         if (metricPairs.length > 0) logLine(`Metrics ${metricPairs.join(' ')}`);
 
         if (isJsonMode) {
-          output.json({ success: true, ...result, repo: githubConfig.repo });
+          const syncedItemsWithUrls = result.syncedItems.map(si => ({
+            action: si.action,
+            id: si.id,
+            title: si.title,
+            url: `https://github.com/${githubConfig.repo}/issues/${si.issueNumber}`,
+          }));
+          const errorItemsJson = result.errorItems.map(ei => ({
+            id: ei.id,
+            title: ei.title,
+            error: ei.error,
+          }));
+          output.json({
+            success: true,
+            ...result,
+            syncedItems: syncedItemsWithUrls,
+            errorItems: errorItemsJson,
+            repo: githubConfig.repo,
+          });
         } else {
           console.log(`GitHub sync complete (${githubConfig.repo})`);
           console.log(`  Created: ${result.created}`);
@@ -202,6 +219,23 @@ export default function register(ctx: PluginContext): void {
           if (result.errors.length > 0) {
             console.log(`  Errors: ${result.errors.length}`);
             console.log('  Hint: re-run with --json to view error details');
+          }
+          // Per-item sync output
+          if (result.syncedItems.length > 0) {
+            console.log('');
+            console.log('  Synced items:');
+            for (const si of result.syncedItems) {
+              const url = `https://github.com/${githubConfig.repo}/issues/${si.issueNumber}`;
+              const actionLabel = si.action.padEnd(7);
+              console.log(`    ${actionLabel}  ${si.id}  ${si.title}  ${url}`);
+            }
+          }
+          if (result.errorItems.length > 0) {
+            console.log('');
+            console.log('  Errors:');
+            for (const ei of result.errorItems) {
+              console.log(`    ${ei.id}  ${ei.title}  ${ei.error}`);
+            }
           }
             if (isVerbose) {
               console.log('  Timing breakdown:');

--- a/src/github-sync.ts
+++ b/src/github-sync.ts
@@ -37,12 +37,27 @@ import {
 import { increment, snapshot, diff } from './github-metrics.js';
 import { mergeWorkItems } from './sync.js';
 
+export interface SyncedItem {
+  action: 'created' | 'updated' | 'closed';
+  id: string;
+  title: string;
+  issueNumber: number;
+}
+
+export interface SyncErrorItem {
+  id: string;
+  title: string;
+  error: string;
+}
+
 export interface GithubSyncResult {
   updated: number;
   created: number;
   closed: number;
   skipped: number;
   errors: string[];
+  syncedItems: SyncedItem[];
+  errorItems: SyncErrorItem[];
   commentsCreated?: number;
   commentsUpdated?: number;
 }
@@ -96,7 +111,7 @@ export async function upsertIssuesFromWorkItems(
   }
 
   const updatedItems: WorkItem[] = [...items];
-  const result: GithubSyncResult = { updated: 0, created: 0, closed: 0, skipped: 0, errors: [] };
+  const result: GithubSyncResult = { updated: 0, created: 0, closed: 0, skipped: 0, errors: [], syncedItems: [], errorItems: [] };
   const updatedById = new Map<string, WorkItem>();
   let processed = 0;
   let skippedUpdates = 0;
@@ -233,6 +248,9 @@ export async function upsertIssuesFromWorkItems(
   // Concurrency: upsert issues and comments with a bounded concurrency pool
   const upsertConcurrency = Number(process.env.WL_GITHUB_CONCURRENCY || '6');
 
+  const truncateTitle = (title: string, maxLen = 60): string =>
+    title.length <= maxLen ? title : title.slice(0, maxLen - 1) + '\u2026';
+
   async function upsertMapper(item: WorkItem, idx: number) {
     if (onProgress) {
       onProgress({ phase: 'push', current: idx + 1, total: issueItems.length });
@@ -279,8 +297,20 @@ export async function upsertIssuesFromWorkItems(
           issue = await updateGithubIssueAsync(config, item.githubIssueNumber, payload);
           if (item.status === 'deleted') {
             result.closed += 1;
+            result.syncedItems.push({
+              action: 'closed',
+              id: item.id,
+              title: truncateTitle(item.title),
+              issueNumber: item.githubIssueNumber,
+            });
           } else {
             result.updated += 1;
+            result.syncedItems.push({
+              action: 'updated',
+              id: item.id,
+              title: truncateTitle(item.title),
+              issueNumber: item.githubIssueNumber,
+            });
           }
         } else {
           increment('api.issue.create');
@@ -290,6 +320,12 @@ export async function upsertIssuesFromWorkItems(
             labels: payload.labels,
           });
           result.created += 1;
+          result.syncedItems.push({
+            action: 'created',
+            id: item.id,
+            title: truncateTitle(item.title),
+            issueNumber: issue.number,
+          });
         }
         timing.upsertMs += Date.now() - upsertStart;
         if (onVerboseLog) {
@@ -327,6 +363,11 @@ export async function upsertIssuesFromWorkItems(
       });
     } catch (error) {
       result.errors.push(`${item.id}: ${(error as Error).message}`);
+      result.errorItems.push({
+        id: item.id,
+        title: truncateTitle(item.title),
+        error: (error as Error).message,
+      });
       updatedById.set(item.id, item);
     }
   }

--- a/tests/github-sync-output.test.ts
+++ b/tests/github-sync-output.test.ts
@@ -1,0 +1,390 @@
+/**
+ * Tests for per-item sync output (syncedItems / errorItems) in github-sync.
+ *
+ * Validates that:
+ * - syncedItems collects created, updated, and closed items with correct action, id, title, issueNumber
+ * - Titles longer than 60 characters are truncated with an ellipsis
+ * - Skipped items are NOT included in syncedItems
+ * - Errored items are collected in errorItems with id, title, and error message
+ * - A mixed set produces the correct syncedItems and errorItems arrays
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// Mock the github module before importing github-sync
+vi.mock('../src/github.js', () => ({
+  normalizeGithubLabelPrefix: (p?: string) => p || 'wl:',
+  workItemToIssuePayload: (_item: any, _comments: any[], _prefix: string, _all: any[]) => ({
+    title: _item.title,
+    body: '',
+    labels: [],
+    state: _item.status === 'completed' || _item.status === 'deleted' ? 'closed' : 'open',
+  }),
+  updateGithubIssueAsync: vi.fn(async (_config: any, _num: number, _payload: any) => ({
+    number: _num,
+    id: `ID_${_num}`,
+    updatedAt: new Date().toISOString(),
+  })),
+  createGithubIssueAsync: vi.fn(async (_config: any, _payload: any) => ({
+    number: 999,
+    id: 'ID_999',
+    updatedAt: new Date().toISOString(),
+  })),
+  getGithubIssueAsync: vi.fn(),
+  listGithubIssues: vi.fn(() => []),
+  getGithubIssue: vi.fn(),
+  listGithubIssueComments: vi.fn(() => []),
+  listGithubIssueCommentsAsync: vi.fn(async () => []),
+  createGithubIssueComment: vi.fn(),
+  createGithubIssueCommentAsync: vi.fn(),
+  updateGithubIssueComment: vi.fn(),
+  updateGithubIssueCommentAsync: vi.fn(),
+  stripWorklogMarkers: vi.fn((s: string) => s),
+  extractWorklogId: vi.fn(),
+  extractWorklogCommentId: vi.fn(),
+  extractParentId: vi.fn(),
+  extractParentIssueNumber: vi.fn(),
+  extractChildIds: vi.fn(),
+  extractChildIssueNumbers: vi.fn(),
+  getIssueHierarchy: vi.fn(() => ({ parentIssueNumber: null, childIssueNumbers: [] })),
+  getIssueHierarchyAsync: vi.fn(async () => ({ parentIssueNumber: null, childIssueNumbers: [] })),
+  addSubIssueLink: vi.fn(),
+  addSubIssueLinkResult: vi.fn(() => ({ ok: true })),
+  addSubIssueLinkResultAsync: vi.fn(async () => ({ ok: true })),
+  buildWorklogCommentMarker: vi.fn(),
+  createGithubIssue: vi.fn(),
+  updateGithubIssue: vi.fn(),
+  issueToWorkItemFields: vi.fn(),
+}));
+
+vi.mock('../src/github-metrics.js', () => ({
+  increment: vi.fn(),
+  snapshot: vi.fn(() => ({})),
+  diff: vi.fn(() => ({})),
+}));
+
+import { upsertIssuesFromWorkItems } from '../src/github-sync.js';
+import { updateGithubIssueAsync, createGithubIssueAsync } from '../src/github.js';
+import type { WorkItem } from '../src/types.js';
+
+const baseTime = new Date('2025-01-01T00:00:00.000Z').toISOString();
+const laterTime = new Date('2025-01-02T00:00:00.000Z').toISOString();
+
+function makeItem(overrides: Partial<WorkItem> & { id: string }): WorkItem {
+  return {
+    title: overrides.id,
+    description: '',
+    status: 'open',
+    priority: 'medium',
+    sortIndex: 0,
+    parentId: null,
+    createdAt: baseTime,
+    updatedAt: baseTime,
+    tags: [],
+    assignee: '',
+    stage: '',
+    issueType: '',
+    createdBy: '',
+    deletedBy: '',
+    deleteReason: '',
+    risk: '',
+    effort: '',
+    ...overrides,
+  } as WorkItem;
+}
+
+const dummyConfig = {
+  owner: 'test',
+  repo: 'test/repo',
+  token: 'test-token',
+};
+
+describe('github-sync per-item sync output', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('created item appears in syncedItems with action "created"', async () => {
+    const newItem = makeItem({
+      id: 'NEW-1',
+      title: 'A brand new item',
+      status: 'open',
+      updatedAt: laterTime,
+    });
+
+    const { result } = await upsertIssuesFromWorkItems(
+      [newItem],
+      [],
+      dummyConfig as any,
+    );
+
+    expect(result.syncedItems).toHaveLength(1);
+    expect(result.syncedItems[0]).toEqual({
+      action: 'created',
+      id: 'NEW-1',
+      title: 'A brand new item',
+      issueNumber: 999,
+    });
+  });
+
+  it('updated item appears in syncedItems with action "updated"', async () => {
+    const updatedItem = makeItem({
+      id: 'UPD-1',
+      title: 'Updated work item',
+      status: 'open',
+      githubIssueNumber: 42,
+      githubIssueUpdatedAt: baseTime,
+      updatedAt: laterTime,
+    });
+
+    const { result } = await upsertIssuesFromWorkItems(
+      [updatedItem],
+      [],
+      dummyConfig as any,
+    );
+
+    expect(result.syncedItems).toHaveLength(1);
+    expect(result.syncedItems[0]).toEqual({
+      action: 'updated',
+      id: 'UPD-1',
+      title: 'Updated work item',
+      issueNumber: 42,
+    });
+  });
+
+  it('closed (deleted) item appears in syncedItems with action "closed"', async () => {
+    const deletedItem = makeItem({
+      id: 'DEL-1',
+      title: 'Deleted item to close',
+      status: 'deleted',
+      githubIssueNumber: 77,
+      githubIssueUpdatedAt: baseTime,
+      updatedAt: laterTime,
+    });
+
+    const { result } = await upsertIssuesFromWorkItems(
+      [deletedItem],
+      [],
+      dummyConfig as any,
+    );
+
+    expect(result.syncedItems).toHaveLength(1);
+    expect(result.syncedItems[0]).toEqual({
+      action: 'closed',
+      id: 'DEL-1',
+      title: 'Deleted item to close',
+      issueNumber: 77,
+    });
+  });
+
+  it('skipped items are NOT included in syncedItems', async () => {
+    const unchangedItem = makeItem({
+      id: 'SKIP-1',
+      title: 'Unchanged item',
+      status: 'open',
+      githubIssueNumber: 100,
+      githubIssueUpdatedAt: laterTime,
+      updatedAt: baseTime, // updatedAt <= githubIssueUpdatedAt => skipped
+    });
+
+    const { result } = await upsertIssuesFromWorkItems(
+      [unchangedItem],
+      [],
+      dummyConfig as any,
+    );
+
+    expect(result.syncedItems).toHaveLength(0);
+    expect(result.skipped).toBe(1);
+  });
+
+  it('truncates titles longer than 60 characters', async () => {
+    const longTitle = 'A'.repeat(80);
+    const item = makeItem({
+      id: 'LONG-TITLE',
+      title: longTitle,
+      status: 'open',
+      updatedAt: laterTime,
+    });
+
+    const { result } = await upsertIssuesFromWorkItems(
+      [item],
+      [],
+      dummyConfig as any,
+    );
+
+    expect(result.syncedItems).toHaveLength(1);
+    expect(result.syncedItems[0].title.length).toBe(60);
+    expect(result.syncedItems[0].title).toBe('A'.repeat(59) + '\u2026');
+  });
+
+  it('does not truncate titles of exactly 60 characters', async () => {
+    const title60 = 'B'.repeat(60);
+    const item = makeItem({
+      id: 'EXACT-60',
+      title: title60,
+      status: 'open',
+      updatedAt: laterTime,
+    });
+
+    const { result } = await upsertIssuesFromWorkItems(
+      [item],
+      [],
+      dummyConfig as any,
+    );
+
+    expect(result.syncedItems).toHaveLength(1);
+    expect(result.syncedItems[0].title).toBe(title60);
+  });
+
+  it('errored items appear in errorItems with id, title, and error message', async () => {
+    const errorMsg = 'API rate limit exceeded';
+    (updateGithubIssueAsync as ReturnType<typeof vi.fn>).mockRejectedValueOnce(new Error(errorMsg));
+
+    const item = makeItem({
+      id: 'ERR-1',
+      title: 'Item that errors',
+      status: 'open',
+      githubIssueNumber: 55,
+      githubIssueUpdatedAt: baseTime,
+      updatedAt: laterTime,
+    });
+
+    const { result } = await upsertIssuesFromWorkItems(
+      [item],
+      [],
+      dummyConfig as any,
+    );
+
+    expect(result.syncedItems).toHaveLength(0);
+    expect(result.errorItems).toHaveLength(1);
+    expect(result.errorItems[0]).toEqual({
+      id: 'ERR-1',
+      title: 'Item that errors',
+      error: errorMsg,
+    });
+    expect(result.errors).toContain('ERR-1: API rate limit exceeded');
+  });
+
+  it('mixed set produces correct syncedItems and errorItems', async () => {
+    const newItem = makeItem({
+      id: 'MIX-NEW',
+      title: 'New item',
+      status: 'open',
+      updatedAt: laterTime,
+    });
+    const updatedItem = makeItem({
+      id: 'MIX-UPD',
+      title: 'Updated item',
+      status: 'open',
+      githubIssueNumber: 200,
+      githubIssueUpdatedAt: baseTime,
+      updatedAt: laterTime,
+    });
+    const closedItem = makeItem({
+      id: 'MIX-DEL',
+      title: 'Closed item',
+      status: 'deleted',
+      githubIssueNumber: 201,
+      githubIssueUpdatedAt: baseTime,
+      updatedAt: laterTime,
+    });
+    const skippedItem = makeItem({
+      id: 'MIX-SKIP',
+      title: 'Skipped item',
+      status: 'open',
+      githubIssueNumber: 202,
+      githubIssueUpdatedAt: laterTime,
+      updatedAt: baseTime,
+    });
+    const errorItem = makeItem({
+      id: 'MIX-ERR',
+      title: 'Error item',
+      status: 'open',
+      githubIssueNumber: 203,
+      githubIssueUpdatedAt: baseTime,
+      updatedAt: laterTime,
+    });
+
+    // Make the error item fail
+    (updateGithubIssueAsync as ReturnType<typeof vi.fn>).mockImplementation(
+      async (_config: any, num: number, _payload: any) => {
+        if (num === 203) {
+          throw new Error('Server error');
+        }
+        return {
+          number: num,
+          id: `ID_${num}`,
+          updatedAt: new Date().toISOString(),
+        };
+      },
+    );
+
+    const { result } = await upsertIssuesFromWorkItems(
+      [newItem, updatedItem, closedItem, skippedItem, errorItem],
+      [],
+      dummyConfig as any,
+    );
+
+    // Synced items: new (created), updated (updated), closed (closed)
+    expect(result.syncedItems).toHaveLength(3);
+    const actions = result.syncedItems.map(si => si.action);
+    expect(actions).toContain('created');
+    expect(actions).toContain('updated');
+    expect(actions).toContain('closed');
+
+    // Verify individual entries
+    const created = result.syncedItems.find(si => si.action === 'created');
+    expect(created).toEqual({
+      action: 'created',
+      id: 'MIX-NEW',
+      title: 'New item',
+      issueNumber: 999,
+    });
+
+    const updated = result.syncedItems.find(si => si.action === 'updated');
+    expect(updated).toEqual({
+      action: 'updated',
+      id: 'MIX-UPD',
+      title: 'Updated item',
+      issueNumber: 200,
+    });
+
+    const closed = result.syncedItems.find(si => si.action === 'closed');
+    expect(closed).toEqual({
+      action: 'closed',
+      id: 'MIX-DEL',
+      title: 'Closed item',
+      issueNumber: 201,
+    });
+
+    // Error items
+    expect(result.errorItems).toHaveLength(1);
+    expect(result.errorItems[0]).toEqual({
+      id: 'MIX-ERR',
+      title: 'Error item',
+      error: 'Server error',
+    });
+
+    // Skipped should NOT appear in either
+    const allIds = [...result.syncedItems.map(si => si.id), ...result.errorItems.map(ei => ei.id)];
+    expect(allIds).not.toContain('MIX-SKIP');
+  });
+
+  it('deleted item without githubIssueNumber does not appear in syncedItems', async () => {
+    const deletedNoIssue = makeItem({
+      id: 'DEL-NO-ISSUE',
+      title: 'Deleted without issue number',
+      status: 'deleted',
+    });
+
+    const { result } = await upsertIssuesFromWorkItems(
+      [deletedNoIssue],
+      [],
+      dummyConfig as any,
+    );
+
+    expect(result.syncedItems).toHaveLength(0);
+    expect(result.errorItems).toHaveLength(0);
+    expect(result.skipped).toBe(1);
+  });
+});


### PR DESCRIPTION
## Summary

After `wl github push` completes, output a per-item table showing the action (created/updated/closed), work item ID, truncated title, and GitHub issue URL for each synced item. Errored items are listed in a separate section.

- **JSON mode**: includes structured `syncedItems` array (with `action`, `id`, `title`, `url` fields) and `errorItems` array in the result object
- **Non-JSON mode**: prints a human-readable table after the aggregate summary, plus a separate errors section
- Skipped (unchanged) items are excluded from the output

## Changes

- `src/github-sync.ts`: Added `SyncedItem` and `SyncErrorItem` interfaces, `truncateTitle()` helper, and collection logic in `upsertMapper`
- `src/commands/github.ts`: Updated JSON and non-JSON output to display per-item sync results with computed GitHub URLs
- `tests/github-sync-output.test.ts`: 9 new tests covering all acceptance criteria

## Acceptance Criteria

1. ✅ Each synced item reported with: action, work item ID, title (truncated to ~60 chars), GitHub URL
2. ✅ JSON mode includes `syncedItems` array with `action`, `id`, `title`, `url` fields
3. ✅ Non-JSON mode prints human-readable table after aggregate summary
4. ✅ Skipped (unchanged) items NOT listed
5. ✅ Errored items listed in separate "errors" section with item ID and error message
6. ✅ Output does not contaminate structured JSON

## Testing

- All 678 tests pass
- Build passes cleanly
- 9 new tests in `tests/github-sync-output.test.ts`

Resolves WL-0MLWU03N203Z3QWW