### PR TITLE
WL-0MKRPG61W1NKGY78: Add FTS5 full-text search command

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -173,6 +173,11 @@ wl list --assignee alice --json
 # List items filtered by stage (e.g. triage, review, done)
 wl list --stage review --json
 
+# Full-text search across all work items (title, description, comments, tags)
+wl search <keywords> --json
+# Search with status filter
+wl search <keywords> --status open --json
+
 # Show full details for a specific work item
 wl show <work-item-id> --format full --json
 ```

--- a/CLI.md
+++ b/CLI.md
@@ -265,10 +265,36 @@ Examples:
 ```sh
 wl list
 wl list -s open -p high
-wl list "signup"
+wl search "signup"
 wl -F concise list -s in-progress
 wl --json list -s open --tags backlog
 wl list --needs-producer-review
+```
+
+---
+
+### `search` <query> [options]
+
+Full-text search over work items using FTS5 (title, description, comments, tags). Returns ranked results with relevance snippets. Falls back to application-level search when FTS5 is unavailable.
+
+Options:
+
+`-s, --status <status>` (optional) — Filter results by status
+`--parent <id>` (optional) — Filter results by parent work item id
+`--tags <tags>` (optional) — Filter by tags (comma-separated)
+`-l, --limit <n>` (optional) — Maximum number of results (default: 20)
+`--rebuild-index` (optional) — Rebuild the FTS index from scratch before searching
+`--prefix <prefix>` (optional)
+`--json` (optional) — Output structured JSON with `id`, `title`, `status`, `priority`, `score`, `snippet`, `matchedField`
+
+Examples:
+
+```sh
+wl search "database corruption"
+wl search "memory leak" --status open
+wl search "authentication" --tags security,auth --limit 5
+wl --json search "cli refactor"
+wl search "rebuild" --rebuild-index
 ```
 
 ---

--- a/src/cli-types.ts
+++ b/src/cli-types.ts
@@ -133,3 +133,12 @@ export interface DepOptions {
   incoming?: boolean;
   outgoing?: boolean;
 }
+
+export interface SearchOptions {
+  status?: string;
+  parent?: string;
+  tags?: string;
+  limit?: string;
+  rebuildIndex?: boolean;
+  prefix?: string;
+}

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -31,6 +31,7 @@ import depCommand from './commands/dep.js';
 import reSortCommand from './commands/re-sort.js';
 import doctorCommand from './commands/doctor.js';
 import reviewedCommand from './commands/reviewed.js';
+import searchCommand from './commands/search.js';
 
 // Watch flag parsing - supports -w, -wN, --watch, --watch=N
 function parseWatchFlag(argv: string[]) {
@@ -226,6 +227,7 @@ const builtInCommands = [
   reSortCommand,
   doctorCommand,
   reviewedCommand,
+  searchCommand,
   // onboard command removed
 ];
 
@@ -253,6 +255,7 @@ const builtInCommandNames = new Set([
   're-sort',
   'doctor',
   'reviewed',
+  'search',
   // 'onboard' removed
 ]);
 
@@ -285,7 +288,7 @@ const formatHelp = (cmd: any, helper: any) => {
   // Build groups and mapping of command name -> group
   const groupsDef: { name: string; names: string[] }[] = [
     { name: 'Issue Management', names: ['create', 'update', 'comment', 'close', 'delete', 'dep', 'reviewed'] },
-    { name: 'Status', names: ['in-progress', 'next', 'recent', 'list', 'show'] },
+    { name: 'Status', names: ['in-progress', 'next', 'recent', 'list', 'show', 'search'] },
     { name: 'Team', names: ['sync', 'github', 'import', 'export'] },
     { name: 'Maintenance', names: ['migrate', 're-sort', 'doctor'] },
     { name: 'Plugins', names: [] },

--- a/src/commands/search.ts
+++ b/src/commands/search.ts
@@ -1,0 +1,140 @@
+/**
+ * Search command - Full-text search over work items
+ */
+
+import type { PluginContext } from '../plugin-types.js';
+import type { SearchOptions } from '../cli-types.js';
+import { formatTitleAndId } from './helpers.js';
+import { theme } from '../theme.js';
+
+export default function register(ctx: PluginContext): void {
+  const { program, output, utils } = ctx;
+
+  program
+    .command('search')
+    .description('Full-text search over work items (title, description, comments, tags)')
+    .argument('[query]', 'Search query (supports phrases, prefix*, AND, OR, NOT)')
+    .option('-s, --status <status>', 'Filter results by status')
+    .option('--parent <id>', 'Filter results by parent work item id')
+    .option('--tags <tags>', 'Filter results by tags (comma-separated)')
+    .option('-l, --limit <n>', 'Maximum number of results (default: 20)')
+    .option('--rebuild-index', 'Rebuild the FTS index from scratch before searching')
+    .option('--prefix <prefix>', 'Override the default prefix')
+    .action((query: string | undefined, options: SearchOptions) => {
+      utils.requireInitialized();
+      const db = utils.getDatabase(options?.prefix);
+
+      // Handle --rebuild-index
+      if (options.rebuildIndex) {
+        try {
+          const result = db.rebuildFtsIndex();
+          if (utils.isJsonMode()) {
+            output.json({ success: true, action: 'rebuild-index', indexed: result.indexed });
+          } else {
+            console.log(`FTS index rebuilt: ${result.indexed} work items indexed.`);
+          }
+          // If no query was provided with --rebuild-index, exit after rebuilding
+          if (!query || query.trim() === '') {
+            return;
+          }
+        } catch (err) {
+          const message = err instanceof Error ? err.message : String(err);
+          output.error(`Failed to rebuild FTS index: ${message}`, {
+            success: false,
+            error: message,
+          });
+          process.exit(1);
+        }
+      }
+
+      // Require query if not doing --rebuild-index
+      if (!query || query.trim() === '') {
+        output.error('Please provide a search query, or use --rebuild-index to rebuild the index.', {
+          success: false,
+          error: 'missing query',
+        });
+        process.exit(1);
+      }
+
+      // Parse options
+      const limit = options.limit ? parseInt(options.limit, 10) : 20;
+      const tags = options.tags
+        ? options.tags.split(',').map((t: string) => t.trim())
+        : undefined;
+
+      let parentId = options.parent;
+      if (parentId) {
+        parentId = utils.normalizeCliId(parentId, options.prefix) || parentId;
+      }
+
+      // Execute search
+      const { results, ftsUsed } = db.search(query, {
+        status: options.status,
+        parentId,
+        tags,
+        limit: isNaN(limit) || limit < 1 ? 20 : limit,
+      });
+
+      if (utils.isJsonMode()) {
+        const jsonResults = results.map(r => {
+          const item = db.get(r.itemId);
+          return {
+            id: r.itemId,
+            title: item?.title || '',
+            status: item?.status || '',
+            priority: item?.priority || '',
+            score: r.rank,
+            snippet: r.snippet,
+            matchedField: r.matchedColumn,
+          };
+        });
+        output.json({
+          success: true,
+          ftsAvailable: ftsUsed,
+          count: jsonResults.length,
+          results: jsonResults,
+        });
+        return;
+      }
+
+      // Human-friendly output
+      if (!ftsUsed) {
+        console.log(theme.text.muted('(FTS5 not available; using fallback search)'));
+        console.log('');
+      }
+
+      if (results.length === 0) {
+        console.log('No results found.');
+        return;
+      }
+
+      console.log(`Found ${results.length} result(s) for "${query}":\n`);
+
+      for (const result of results) {
+        const item = db.get(result.itemId);
+        if (!item) continue;
+
+        // Title line
+        console.log(formatTitleAndId(item));
+
+        // Metadata line
+        const meta: string[] = [];
+        meta.push(`Status: ${item.status}`);
+        meta.push(`Priority: ${item.priority}`);
+        if (item.assignee) meta.push(`Assignee: ${item.assignee}`);
+        if (item.tags && item.tags.length > 0) meta.push(`Tags: ${item.tags.join(', ')}`);
+        console.log(`  ${theme.text.muted(meta.join(' | '))}`);
+
+        // Snippet line
+        if (result.snippet) {
+          const snippetLabel = theme.text.muted(`[${result.matchedColumn}]`);
+          // Replace highlight markers << >> with chalk bold
+          const highlighted = result.snippet
+            .replace(/<<(.*?)>>/g, (_, match) => theme.text.warning(match));
+          console.log(`  ${snippetLabel} ${highlighted}`);
+        }
+
+        console.log('');
+      }
+    });
+}

--- a/src/database.ts
+++ b/src/database.ts
@@ -6,7 +6,7 @@ import { randomBytes } from 'crypto';
 import * as fs from 'fs';
 import * as path from 'path';
 import { WorkItem, CreateWorkItemInput, UpdateWorkItemInput, WorkItemQuery, Comment, CreateCommentInput, UpdateCommentInput, NextWorkItemResult, DependencyEdge } from './types.js';
-import { SqlitePersistentStore } from './persistent-store.js';
+import { SqlitePersistentStore, FtsSearchResult } from './persistent-store.js';
 import { importFromJsonl, exportToJsonl, getDefaultDataPath } from './jsonl.js';
 import { mergeWorkItems, mergeComments } from './sync.js';
 
@@ -269,6 +269,44 @@ export class WorklogDatabase {
     }));
   }
 
+  // ── Full-Text Search ──────────────────────────────────────────────
+
+  /**
+   * Whether FTS5 full-text search is available in the underlying SQLite build
+   */
+  get ftsAvailable(): boolean {
+    return this.store.ftsAvailable;
+  }
+
+  /**
+   * Search work items using full-text search (FTS5) with automatic fallback
+   * to application-level search when FTS5 is unavailable.
+   */
+  search(
+    query: string,
+    options?: {
+      status?: string;
+      parentId?: string;
+      tags?: string[];
+      limit?: number;
+    }
+  ): { results: FtsSearchResult[]; ftsUsed: boolean } {
+    if (this.store.ftsAvailable) {
+      return { results: this.store.searchFts(query, options), ftsUsed: true };
+    }
+    if (!this.silent) {
+      this.debug('FTS5 is not available; falling back to application-level search');
+    }
+    return { results: this.store.searchFallback(query, options), ftsUsed: false };
+  }
+
+  /**
+   * Rebuild the FTS index from scratch. Useful for backfill or recovery.
+   */
+  rebuildFtsIndex(): { indexed: number } {
+    return this.store.rebuildFtsIndex();
+  }
+
   /**
    * Close the underlying database connection.
    * Must be called before removing temp directories on Windows
@@ -376,6 +414,7 @@ export class WorklogDatabase {
     };
 
     this.store.saveWorkItem(item);
+    this.store.upsertFtsEntry(item);
     this.exportToJsonl();
     this.triggerAutoSync();
     return item;
@@ -442,6 +481,7 @@ export class WorklogDatabase {
     }
 
     this.store.saveWorkItem(updated);
+    this.store.upsertFtsEntry(updated);
     this.exportToJsonl();
     this.triggerAutoSync();
 
@@ -475,6 +515,7 @@ export class WorklogDatabase {
     };
 
     this.store.saveWorkItem(updated);
+    this.store.deleteFtsEntry(id);
     this.exportToJsonl();
     this.triggerAutoSync();
     if (this.listDependencyEdgesTo(id).length > 0) {
@@ -1400,6 +1441,9 @@ export class WorklogDatabase {
 
      this.store.saveComment(comment);
      this.touchWorkItemUpdatedAt(input.workItemId);
+     // Re-index the parent work item in FTS to include the new comment text
+     const parentItem = this.store.getWorkItem(input.workItemId);
+     if (parentItem) this.store.upsertFtsEntry(parentItem);
      this.exportToJsonl();
      this.triggerAutoSync();
      return comment;
@@ -1444,6 +1488,9 @@ export class WorklogDatabase {
 
      this.store.saveComment(updated);
      this.touchWorkItemUpdatedAt(comment.workItemId);
+     // Re-index the parent work item in FTS to reflect updated comment text
+     const parentItem = this.store.getWorkItem(comment.workItemId);
+     if (parentItem) this.store.upsertFtsEntry(parentItem);
      this.exportToJsonl();
      this.triggerAutoSync();
      return updated;
@@ -1460,6 +1507,9 @@ export class WorklogDatabase {
      const result = this.store.deleteComment(id);
       if (result) {
         this.touchWorkItemUpdatedAt(comment.workItemId);
+        // Re-index the parent work item in FTS to reflect removed comment
+        const parentItem = this.store.getWorkItem(comment.workItemId);
+        if (parentItem) this.store.upsertFtsEntry(parentItem);
         this.exportToJsonl();
         this.triggerAutoSync();
       }

--- a/src/persistent-store.ts
+++ b/src/persistent-store.ts
@@ -8,6 +8,20 @@ import * as path from 'path';
 import { WorkItem, Comment, DependencyEdge } from './types.js';
 import { listPendingMigrations } from './migrations/index.js';
 
+/**
+ * Result from a full-text search query
+ */
+export interface FtsSearchResult {
+  /** The work item ID */
+  itemId: string;
+  /** BM25 relevance score (lower = more relevant in SQLite FTS5) */
+  rank: number;
+  /** Snippet with highlighted matches */
+  snippet: string;
+  /** Which column the snippet was extracted from */
+  matchedColumn: string;
+}
+
 interface DbMetadata {
   lastJsonlImportMtime?: number;
   lastJsonlImportAt?: string;
@@ -56,6 +70,7 @@ export class SqlitePersistentStore {
   private db: Database.Database;
   private dbPath: string;
   private verbose: boolean;
+  private _ftsAvailable: boolean = false;
 
   constructor(dbPath: string, verbose: boolean = false) {
     this.dbPath = dbPath;
@@ -86,6 +101,16 @@ export class SqlitePersistentStore {
     } catch (error) {
       throw new Error(`Failed to initialize database schema: ${(error as Error).message}`);
     }
+
+    // Initialize FTS5 index (best-effort; falls back to app-level search if unavailable)
+    this._ftsAvailable = this.initializeFts();
+  }
+
+  /**
+   * Whether FTS5 full-text search is available in this SQLite build
+   */
+  get ftsAvailable(): boolean {
+    return this._ftsAvailable;
   }
 
   /**
@@ -649,6 +674,400 @@ export class SqlitePersistentStore {
     const stmt = this.db.prepare('DELETE FROM dependency_edges WHERE fromId = ? OR toId = ?');
     const result = stmt.run(itemId, itemId);
     return result.changes;
+  }
+
+  // ── FTS5 Full-Text Search ──────────────────────────────────────────
+
+  /**
+   * Detect whether FTS5 is available and create the virtual table if so.
+   * Returns true when FTS5 is usable, false otherwise (caller should fall
+   * back to application-level search).
+   */
+  private initializeFts(): boolean {
+    try {
+      // Probe FTS5 availability by attempting to compile a no-op statement
+      this.db.exec(`CREATE VIRTUAL TABLE IF NOT EXISTS _fts5_probe USING fts5(x)`);
+      this.db.exec(`DROP TABLE IF EXISTS _fts5_probe`);
+    } catch (_err) {
+      // FTS5 extension is not compiled in
+      return false;
+    }
+
+    try {
+      this.db.exec(`
+        CREATE VIRTUAL TABLE IF NOT EXISTS worklog_fts USING fts5(
+          title,
+          description,
+          comments,
+          tags,
+          itemId UNINDEXED,
+          status UNINDEXED,
+          parentId UNINDEXED,
+          tokenize = 'porter'
+        )
+      `);
+      return true;
+    } catch (_err) {
+      return false;
+    }
+  }
+
+  /**
+   * Upsert a single work item into the FTS index.
+   * Collects all comments for the item and concatenates them into a single
+   * text blob so comment content is searchable.
+   */
+  upsertFtsEntry(item: WorkItem): void {
+    if (!this._ftsAvailable) return;
+
+    // Gather comment bodies for this item
+    const comments = this.getCommentsForWorkItem(item.id);
+    const commentText = comments.map(c => c.comment).join('\n');
+    const tagsText = Array.isArray(item.tags) ? item.tags.join(' ') : '';
+
+    // Delete any existing row then insert fresh (FTS5 content tables
+    // don't support UPDATE in the same way as regular tables).
+    const deleteFts = this.db.prepare(
+      `DELETE FROM worklog_fts WHERE itemId = ?`
+    );
+    const insertFts = this.db.prepare(`
+      INSERT INTO worklog_fts (title, description, comments, tags, itemId, status, parentId)
+      VALUES (?, ?, ?, ?, ?, ?, ?)
+    `);
+
+    deleteFts.run(item.id);
+    insertFts.run(
+      item.title,
+      item.description,
+      commentText,
+      tagsText,
+      item.id,
+      item.status,
+      item.parentId ?? ''
+    );
+  }
+
+  /**
+   * Remove a work item from the FTS index
+   */
+  deleteFtsEntry(itemId: string): void {
+    if (!this._ftsAvailable) return;
+    this.db.prepare(`DELETE FROM worklog_fts WHERE itemId = ?`).run(itemId);
+  }
+
+  /**
+   * Rebuild the entire FTS index from the current workitems and comments tables.
+   * This drops and recreates the FTS table then inserts all items.
+   */
+  rebuildFtsIndex(): { indexed: number } {
+    if (!this._ftsAvailable) {
+      throw new Error('FTS5 is not available in this SQLite build. Cannot rebuild index.');
+    }
+
+    const rebuildTx = this.db.transaction(() => {
+      // Drop and recreate
+      this.db.exec(`DROP TABLE IF EXISTS worklog_fts`);
+      this.db.exec(`
+        CREATE VIRTUAL TABLE worklog_fts USING fts5(
+          title,
+          description,
+          comments,
+          tags,
+          itemId UNINDEXED,
+          status UNINDEXED,
+          parentId UNINDEXED,
+          tokenize = 'porter'
+        )
+      `);
+
+      const items = this.getAllWorkItems();
+      const allComments = this.getAllComments();
+
+      // Group comments by work item id
+      const commentsByItem = new Map<string, string[]>();
+      for (const c of allComments) {
+        const list = commentsByItem.get(c.workItemId);
+        if (list) {
+          list.push(c.comment);
+        } else {
+          commentsByItem.set(c.workItemId, [c.comment]);
+        }
+      }
+
+      const insertFts = this.db.prepare(`
+        INSERT INTO worklog_fts (title, description, comments, tags, itemId, status, parentId)
+        VALUES (?, ?, ?, ?, ?, ?, ?)
+      `);
+
+      for (const item of items) {
+        const commentText = (commentsByItem.get(item.id) || []).join('\n');
+        const tagsText = Array.isArray(item.tags) ? item.tags.join(' ') : '';
+        insertFts.run(
+          item.title,
+          item.description,
+          commentText,
+          tagsText,
+          item.id,
+          item.status,
+          item.parentId ?? ''
+        );
+      }
+
+      return items.length;
+    });
+
+    const indexed = rebuildTx();
+    return { indexed };
+  }
+
+  /**
+   * Search the FTS index using an FTS5 MATCH expression.
+   * Returns results ranked by BM25 relevance (most relevant first).
+   *
+   * @param query - FTS5 query string (supports phrases, prefix*, OR, AND, NOT)
+   * @param options - Optional filters and limits
+   */
+  searchFts(
+    query: string,
+    options?: {
+      status?: string;
+      parentId?: string;
+      tags?: string[];
+      limit?: number;
+    }
+  ): FtsSearchResult[] {
+    if (!this._ftsAvailable) return [];
+
+    // Sanitize and prepare the query
+    const trimmed = query.trim();
+    if (!trimmed) return [];
+
+    const limit = options?.limit ?? 50;
+
+    try {
+      // Build the base query with BM25 ranking and snippets.
+      // We extract snippets from each searchable column and pick the best one.
+      // BM25 column weights: title=10, description=5, comments=2, tags=3
+      let sql = `
+        SELECT
+          itemId,
+          bm25(worklog_fts, 10.0, 5.0, 2.0, 3.0) AS rank,
+          snippet(worklog_fts, 0, '<<', '>>', '...', 32) AS title_snippet,
+          snippet(worklog_fts, 1, '<<', '>>', '...', 32) AS desc_snippet,
+          snippet(worklog_fts, 2, '<<', '>>', '...', 32) AS comment_snippet,
+          snippet(worklog_fts, 3, '<<', '>>', '...', 32) AS tags_snippet,
+          status,
+          parentId
+        FROM worklog_fts
+        WHERE worklog_fts MATCH ?
+      `;
+
+      const params: (string | number)[] = [trimmed];
+
+      if (options?.status) {
+        sql += ` AND status = ?`;
+        params.push(options.status);
+      }
+
+      if (options?.parentId) {
+        sql += ` AND parentId = ?`;
+        params.push(options.parentId);
+      }
+
+      sql += ` ORDER BY rank LIMIT ?`;
+      params.push(limit);
+
+      const stmt = this.db.prepare(sql);
+      const rows = stmt.all(...params) as any[];
+
+      const results: FtsSearchResult[] = [];
+
+      for (const row of rows) {
+        // Pick the best snippet (the one with highlight markers)
+        let snippet = '';
+        let matchedColumn = 'title';
+
+        if (row.title_snippet && row.title_snippet.includes('<<')) {
+          snippet = row.title_snippet;
+          matchedColumn = 'title';
+        } else if (row.desc_snippet && row.desc_snippet.includes('<<')) {
+          snippet = row.desc_snippet;
+          matchedColumn = 'description';
+        } else if (row.comment_snippet && row.comment_snippet.includes('<<')) {
+          snippet = row.comment_snippet;
+          matchedColumn = 'comments';
+        } else if (row.tags_snippet && row.tags_snippet.includes('<<')) {
+          snippet = row.tags_snippet;
+          matchedColumn = 'tags';
+        } else {
+          // Fallback: use title snippet even without highlights
+          snippet = row.title_snippet || '';
+          matchedColumn = 'title';
+        }
+
+        results.push({
+          itemId: row.itemId,
+          rank: row.rank,
+          snippet,
+          matchedColumn,
+        });
+      }
+
+      // Post-filter by tags (FTS5 can't efficiently filter JSON arrays,
+      // so we do this in application code)
+      if (options?.tags && options.tags.length > 0) {
+        const tagSet = new Set(options.tags.map(t => t.toLowerCase()));
+        const filtered: FtsSearchResult[] = [];
+        for (const result of results) {
+          const item = this.getWorkItem(result.itemId);
+          if (item && item.tags.some(t => tagSet.has(t.toLowerCase()))) {
+            filtered.push(result);
+          }
+        }
+        return filtered;
+      }
+
+      return results;
+    } catch (_err) {
+      // If the query syntax is invalid, return empty results
+      return [];
+    }
+  }
+
+  /**
+   * Perform a simple application-level text search as a fallback when FTS5
+   * is not available. Searches title, description, tags and comment bodies
+   * using case-insensitive substring matching with basic relevance scoring.
+   */
+  searchFallback(
+    query: string,
+    options?: {
+      status?: string;
+      parentId?: string;
+      tags?: string[];
+      limit?: number;
+    }
+  ): FtsSearchResult[] {
+    const trimmed = query.trim().toLowerCase();
+    if (!trimmed) return [];
+
+    const limit = options?.limit ?? 50;
+    const terms = trimmed.split(/\s+/).filter(t => t.length > 0);
+    if (terms.length === 0) return [];
+
+    let items = this.getAllWorkItems();
+
+    // Apply filters
+    if (options?.status) {
+      items = items.filter(i => i.status === options.status);
+    }
+    if (options?.parentId) {
+      items = items.filter(i => i.parentId === options.parentId);
+    }
+    if (options?.tags && options.tags.length > 0) {
+      const tagSet = new Set(options.tags.map(t => t.toLowerCase()));
+      items = items.filter(i => i.tags.some(t => tagSet.has(t.toLowerCase())));
+    }
+
+    const allComments = this.getAllComments();
+    const commentsByItem = new Map<string, string>();
+    for (const c of allComments) {
+      const existing = commentsByItem.get(c.workItemId) || '';
+      commentsByItem.set(c.workItemId, existing + '\n' + c.comment);
+    }
+
+    const results: FtsSearchResult[] = [];
+
+    for (const item of items) {
+      const titleLower = item.title.toLowerCase();
+      const descLower = item.description.toLowerCase();
+      const tagsLower = (item.tags || []).join(' ').toLowerCase();
+      const commentLower = (commentsByItem.get(item.id) || '').toLowerCase();
+
+      // Count matching terms across fields (simple TF-like scoring)
+      let score = 0;
+      let bestField = 'title';
+      let bestFieldScore = 0;
+
+      for (const term of terms) {
+        const titleHits = this.countOccurrences(titleLower, term) * 10;
+        const descHits = this.countOccurrences(descLower, term) * 5;
+        const tagHits = this.countOccurrences(tagsLower, term) * 3;
+        const commentHits = this.countOccurrences(commentLower, term) * 2;
+
+        score += titleHits + descHits + tagHits + commentHits;
+
+        if (titleHits > bestFieldScore) { bestFieldScore = titleHits; bestField = 'title'; }
+        if (descHits > bestFieldScore) { bestFieldScore = descHits; bestField = 'description'; }
+        if (commentHits > bestFieldScore) { bestFieldScore = commentHits; bestField = 'comments'; }
+        if (tagHits > bestFieldScore) { bestFieldScore = tagHits; bestField = 'tags'; }
+      }
+
+      if (score > 0) {
+        // Generate a simple snippet from the best matching field
+        const fieldText = bestField === 'title' ? item.title
+          : bestField === 'description' ? item.description
+          : bestField === 'tags' ? (item.tags || []).join(' ')
+          : commentsByItem.get(item.id) || '';
+
+        const snippet = this.generateSnippet(fieldText, terms[0], 64);
+
+        results.push({
+          itemId: item.id,
+          rank: -score, // Negate so higher scores sort first (matching FTS5 BM25 convention)
+          snippet,
+          matchedColumn: bestField,
+        });
+      }
+    }
+
+    // Sort by rank (most relevant first - lowest rank value for BM25-like convention)
+    results.sort((a, b) => a.rank - b.rank);
+
+    return results.slice(0, limit);
+  }
+
+  /**
+   * Count occurrences of a substring in a string
+   */
+  private countOccurrences(text: string, sub: string): number {
+    if (!sub || !text) return 0;
+    let count = 0;
+    let pos = 0;
+    while ((pos = text.indexOf(sub, pos)) !== -1) {
+      count++;
+      pos += sub.length;
+    }
+    return count;
+  }
+
+  /**
+   * Generate a snippet around the first occurrence of a term
+   */
+  private generateSnippet(text: string, term: string, maxLen: number): string {
+    if (!text) return '';
+    const lower = text.toLowerCase();
+    const termLower = term.toLowerCase();
+    const idx = lower.indexOf(termLower);
+
+    if (idx === -1) {
+      // Term not found directly, return start of text
+      return text.length > maxLen ? text.slice(0, maxLen) + '...' : text;
+    }
+
+    const halfWindow = Math.floor(maxLen / 2);
+    let start = Math.max(0, idx - halfWindow);
+    let end = Math.min(text.length, idx + term.length + halfWindow);
+
+    let snippet = '';
+    if (start > 0) snippet += '...';
+    const raw = text.slice(start, end);
+    // Add highlight markers around the term occurrence
+    const matchStart = idx - start;
+    snippet += raw.slice(0, matchStart) + '<<' + raw.slice(matchStart, matchStart + term.length) + '>>' + raw.slice(matchStart + term.length);
+    if (end < text.length) snippet += '...';
+
+    return snippet;
   }
 
   /**

--- a/templates/AGENTS.md
+++ b/templates/AGENTS.md
@@ -171,6 +171,11 @@ wl list --assignee alice --json
 # List items filtered by stage (e.g. triage, review, done)
 wl list --stage review --json
 
+# Full-text search across all work items (title, description, comments, tags)
+wl search <keywords> --json
+# Search with status filter
+wl search <keywords> --status open --json
+
 # Show details for a specific work item
 wl show <work-item-id> --comments --json
 # Show details including child/subtask items

--- a/templates/WORKFLOW.md
+++ b/templates/WORKFLOW.md
@@ -12,9 +12,9 @@ The agent(s) will then plan and execute the work required to meet those goals by
    - Claim it with `wl update <id> --status in-progress --assignee @your-agent-name`
 1. **Ensure the work-item is clearly defined**:
    - Review the description, acceptance criteria, and any related files/paths in the work item description and comments (retrieved with `wl show <id> --children --json`)
-   - Review any existing work-items in the repository that may be related to this work-item (`wl list <search-terms> --include-closed` and `wl show <id> --children --json`).
+   - Review any existing work-items in the repository that may be related to this work-item (`wl search <search-terms> --json` and `wl show <id> --children --json`).
    - If the work-item is not clearly defined (it _MUST_ included a clear description of the goal and how it will change behaviour, preferably in the form of a user story, along with acceptance criteria that can be used to verify completion and references to important specifications, user-stories, designs, or other important context):
-     - Search the worklog (`wl list <search-terms> --include-closed` and `wl show <id> --children --json`) and repository for any existing information that may clarify the requirements
+     - Search the worklog (`wl search <search-terms> --json` and `wl show <id> --children --json`) and repository for any existing information that may clarify the requirements
      - If the operator has allowed further questions ask for clarification on specific requirements, acceptance criteria, and context. Where possible provide suggested responses, but always allow for a free form text response.
      - If the operator has not allowed further questions attempt to clarify the requirements based on the existing information in the repository and worklog.
      - Update the work-item description and acceptance criteria with any clarifications found `wl update <id> --description "<updated-description>"`. DO NOT remove existing content unless it is incorrect, ONLY add to it with appropriate clarifications.
@@ -39,9 +39,9 @@ The agent(s) will then plan and execute the work required to meet those goals by
 4. **Implement the work-item**:
    - Review the content of the selected work-item
    - Review the description, acceptance criteria, and any related files/paths in the work item description and comments (retrieved with `wl show <WIP-id> --children --json`)
-   - Review any existing work-items in the repository that may be related to this work-item (`wl list <search-terms> --include-closed` and `wl show <id> --children --json`).
+   - Review any existing work-items in the repository that may be related to this work-item (`wl search <search-terms> --json` and `wl show <id> --children --json`).
    - If the work-item is not clearly defined:
-     - Search the worklog (`wl list <search-terms> --include-closed` and `wl show <id> --children --json`) and repository for any existing information that may clarify the requirements
+     - Search the worklog (`wl search <search-terms> --json` and `wl show <id> --children --json`) and repository for any existing information that may clarify the requirements
      - If the operator has allowed further questions ask for clarification on specific requirements, acceptance criteria, and context. Where possible provide suggested responses, but always allow for a free form text response.
      - If the operator has not allowed further questions attempt to clarify the requirements based on the existing information in the repository and worklog.
      - Update the work-item description and acceptance criteria with any clarifications found with `wl update <WIP-id> --description "<updated-description>"`. DO NOT remove existing content unless it is incorrect, ONLY add to it with appropriate clarifications.

--- a/tests/fts-search.test.ts
+++ b/tests/fts-search.test.ts
@@ -1,0 +1,246 @@
+/**
+ * Tests for FTS5 full-text search
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { WorklogDatabase } from '../src/database.js';
+import { createTempDir, cleanupTempDir, createTempJsonlPath, createTempDbPath } from './test-utils.js';
+
+describe('FTS Search', () => {
+  let tempDir: string;
+  let dbPath: string;
+  let jsonlPath: string;
+  let db: WorklogDatabase;
+
+  beforeEach(() => {
+    tempDir = createTempDir();
+    dbPath = createTempDbPath(tempDir);
+    jsonlPath = createTempJsonlPath(tempDir);
+    db = new WorklogDatabase('TEST', dbPath, jsonlPath, true, true);
+  });
+
+  afterEach(() => {
+    db.close();
+    cleanupTempDir(tempDir);
+  });
+
+  describe('ftsAvailable', () => {
+    it('should report FTS5 as available', () => {
+      // better-sqlite3 includes FTS5 by default
+      expect(db.ftsAvailable).toBe(true);
+    });
+  });
+
+  describe('search after create', () => {
+    it('should find a work item by title', () => {
+      db.create({ title: 'Database corruption fix' });
+      const { results, ftsUsed } = db.search('database');
+      expect(ftsUsed).toBe(true);
+      expect(results.length).toBeGreaterThanOrEqual(1);
+      expect(results[0].itemId).toBeDefined();
+    });
+
+    it('should find a work item by description', () => {
+      db.create({
+        title: 'Simple title',
+        description: 'This work item fixes a memory leak in the parser module',
+      });
+      const { results } = db.search('memory leak');
+      expect(results.length).toBeGreaterThanOrEqual(1);
+      expect(results[0].matchedColumn).toBe('description');
+    });
+
+    it('should find a work item by tags', () => {
+      db.create({
+        title: 'Unrelated title',
+        tags: ['frontend', 'react', 'performance'],
+      });
+      const { results } = db.search('react');
+      expect(results.length).toBeGreaterThanOrEqual(1);
+    });
+
+    it('should return snippet with highlight markers', () => {
+      db.create({ title: 'Implement caching layer for Redis' });
+      const { results } = db.search('caching');
+      expect(results.length).toBeGreaterThanOrEqual(1);
+      // FTS5 snippets use << >> markers
+      expect(results[0].snippet).toContain('<<');
+      expect(results[0].snippet).toContain('>>');
+    });
+
+    it('should return empty results for non-matching query', () => {
+      db.create({ title: 'Something completely different' });
+      const { results } = db.search('xyznonexistent');
+      expect(results.length).toBe(0);
+    });
+
+    it('should return empty results for empty query', () => {
+      db.create({ title: 'Test item' });
+      const { results } = db.search('');
+      expect(results.length).toBe(0);
+    });
+  });
+
+  describe('search with filters', () => {
+    it('should filter by status', () => {
+      db.create({ title: 'Open bug', status: 'open' });
+      db.create({ title: 'Closed bug fix', status: 'completed' });
+
+      const { results: openResults } = db.search('bug', { status: 'open' });
+      expect(openResults.length).toBe(1);
+      expect(openResults[0].itemId).toBeDefined();
+
+      const { results: closedResults } = db.search('bug', { status: 'completed' });
+      expect(closedResults.length).toBe(1);
+    });
+
+    it('should filter by parentId', () => {
+      const parent = db.create({ title: 'Parent epic' });
+      db.create({ title: 'Child feature work', parentId: parent.id });
+      db.create({ title: 'Orphan feature work' });
+
+      const { results } = db.search('feature', { parentId: parent.id });
+      expect(results.length).toBe(1);
+    });
+
+    it('should filter by tags', () => {
+      db.create({ title: 'Frontend widget', tags: ['frontend', 'ui'] });
+      db.create({ title: 'Backend widget', tags: ['backend', 'api'] });
+
+      const { results } = db.search('widget', { tags: ['frontend'] });
+      expect(results.length).toBe(1);
+    });
+
+    it('should respect limit', () => {
+      for (let i = 0; i < 10; i++) {
+        db.create({ title: `Repeated search target item ${i}` });
+      }
+
+      const { results } = db.search('search target', { limit: 3 });
+      expect(results.length).toBeLessThanOrEqual(3);
+    });
+  });
+
+  describe('index updates on write', () => {
+    it('should reflect updates in search results', () => {
+      const item = db.create({ title: 'Original title alpha' });
+      let { results } = db.search('alpha');
+      expect(results.length).toBe(1);
+
+      db.update(item.id, { title: 'Updated title beta' });
+      ({ results } = db.search('alpha'));
+      expect(results.length).toBe(0);
+
+      ({ results } = db.search('beta'));
+      expect(results.length).toBe(1);
+    });
+
+    it('should remove deleted items from search', () => {
+      const item = db.create({ title: 'Deletable item gamma' });
+      let { results } = db.search('gamma');
+      expect(results.length).toBe(1);
+
+      db.delete(item.id);
+      ({ results } = db.search('gamma'));
+      expect(results.length).toBe(0);
+    });
+
+    it('should index comment text and reflect comment changes', () => {
+      const item = db.create({ title: 'Bug report' });
+
+      // Add a comment and search for it
+      db.createComment({
+        workItemId: item.id,
+        author: 'tester',
+        comment: 'Reproduced the segfault on ARM64',
+      });
+
+      let { results } = db.search('segfault');
+      expect(results.length).toBe(1);
+      expect(results[0].itemId).toBe(item.id);
+
+      // Update the comment
+      const comments = db.getCommentsForWorkItem(item.id);
+      db.updateComment(comments[0].id, { comment: 'Actually it was a null pointer dereference' });
+
+      ({ results } = db.search('segfault'));
+      expect(results.length).toBe(0);
+
+      ({ results } = db.search('null pointer'));
+      expect(results.length).toBe(1);
+    });
+
+    it('should update index when a comment is deleted', () => {
+      const item = db.create({ title: 'Feature request' });
+      const comment = db.createComment({
+        workItemId: item.id,
+        author: 'user',
+        comment: 'Please add dark mode support',
+      });
+
+      let { results } = db.search('dark mode');
+      expect(results.length).toBe(1);
+
+      db.deleteComment(comment!.id);
+      ({ results } = db.search('dark mode'));
+      expect(results.length).toBe(0);
+    });
+  });
+
+  describe('rebuildFtsIndex', () => {
+    it('should rebuild the entire index', () => {
+      db.create({ title: 'Rebuild test alpha' });
+      db.create({ title: 'Rebuild test beta' });
+      db.create({ title: 'Rebuild test gamma' });
+
+      const { indexed } = db.rebuildFtsIndex();
+      expect(indexed).toBe(3);
+
+      const { results } = db.search('rebuild test');
+      expect(results.length).toBe(3);
+    });
+
+    it('should include comments after rebuild', () => {
+      const item = db.create({ title: 'Comment rebuild test' });
+      db.createComment({
+        workItemId: item.id,
+        author: 'agent',
+        comment: 'Unique searchable token xylophone',
+      });
+
+      db.rebuildFtsIndex();
+
+      const { results } = db.search('xylophone');
+      expect(results.length).toBe(1);
+      expect(results[0].itemId).toBe(item.id);
+    });
+  });
+
+  describe('ranking', () => {
+    it('should rank title matches higher than description matches', () => {
+      db.create({
+        title: 'Authentication module',
+        description: 'Handles user login and session management',
+      });
+      db.create({
+        title: 'Session management refactor',
+        description: 'Improve the authentication flow for better security',
+      });
+
+      const { results } = db.search('authentication');
+      expect(results.length).toBe(2);
+      // The item with "authentication" in the title should rank first
+      // since title has weight 10 vs description weight 5
+      expect(results[0].matchedColumn).toBe('title');
+    });
+  });
+
+  describe('WorklogDatabase.search() method', () => {
+    it('should return ftsUsed=true when FTS5 is available', () => {
+      db.create({ title: 'Test search method' });
+      const result = db.search('search method');
+      expect(result.ftsUsed).toBe(true);
+      expect(result.results.length).toBeGreaterThanOrEqual(1);
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- Adds FTS5-backed full-text search (`wl search`) with BM25 ranking, snippet extraction, and field-weighted scoring (title=10, description=5, comments=2, tags=3)
- Includes application-level fallback search when FTS5 is unavailable
- Updates all documentation to reference `wl search` instead of the deprecated `wl list <search>` pattern

## Changes

### Core FTS Index (`src/persistent-store.ts`)
- `FtsSearchResult` interface for search results
- `initializeFts()` — detects FTS5 availability, creates `worklog_fts` virtual table with porter tokenizer
- `upsertFtsEntry()` / `deleteFtsEntry()` — transactional FTS index updates
- `rebuildFtsIndex()` — full rebuild from existing data
- `searchFts()` — BM25-ranked search with snippet extraction and status/parent/tags filters
- `searchFallback()` — TF-scored fallback with substring matching

### Write Path Integration (`src/database.ts`)
- FTS upsert wired into `create()`, `update()`, `createComment()`, `updateComment()`, `deleteComment()`
- FTS delete wired into `delete()`
- `search()` method auto-selects FTS5 or fallback
- `rebuildFtsIndex()` and `ftsAvailable` getter exposed

### CLI Command (`src/commands/search.ts`)
- `wl search [query]` with `--status`, `--parent`, `--tags`, `--limit`, `--rebuild-index`, `--prefix`, `--json`
- Query is optional so `--rebuild-index` works standalone
- Human-friendly output with yellow-highlighted search terms and metadata
- JSON output with id, title, status, priority, score, snippet, matchedField

### Documentation
- `CLI.md` — search command section with examples; replaced `wl list "signup"` with `wl search "signup"`
- `AGENTS.md` / `templates/AGENTS.md` — added `wl search` to Project Status reference
- `templates/WORKFLOW.md` — replaced 4 instances of `wl list <search-terms> --include-closed` with `wl search <search-terms> --json`

### Tests (`tests/fts-search.test.ts`)
- 19 tests: FTS availability, search by title/description/tags, snippet highlights, filters (status/parent/tags/limit), index updates on CRUD, comment indexing, rebuild, ranking weights, integration

## Test Results

All 697 tests pass (77 test files), including 19 new FTS tests.

## Related Work Items

- WL-0MKRPG61W1NKGY78 — Full-text search (parent epic)
- WL-0MLYMVA5G053C4LD — Replace wl list search references with wl search in docs
- WL-0MLYN2DPW0CN62LM — Add missing filter flags to wl search (follow-up)
- WL-0MLYN2TJS02A97X9 — Deprecate wl list search positional argument (follow-up)