### PR TITLE
WL-0MLG0DSFT09AKPTK: Process-level mutex for import/export/sync

### DIFF
--- a/src/commands/export.ts
+++ b/src/commands/export.ts
@@ -5,6 +5,7 @@
 import type { PluginContext } from '../plugin-types.js';
 import type { ExportOptions } from '../cli-types.js';
 import { exportToJsonl } from '../jsonl.js';
+import { withFileLock, getLockPathForJsonl } from '../file-lock.js';
 
 export default function register(ctx: PluginContext): void {
   const { program, dataPath, output, utils } = ctx;
@@ -16,22 +17,26 @@ export default function register(ctx: PluginContext): void {
     .option('--prefix <prefix>', 'Override the default prefix')
     .action((options: ExportOptions) => {
       utils.requireInitialized();
-      const db = utils.getDatabase(options.prefix);
-      const items = db.getAll();
-      const comments = db.getAllComments();
-      const dependencyEdges = db.getAllDependencyEdges();
-      exportToJsonl(items, comments, options.file || dataPath, dependencyEdges);
-      
-      if (utils.isJsonMode()) {
-        output.json({ 
-          success: true, 
-          message: `Exported ${items.length} work items and ${comments.length} comments`,
-          itemsCount: items.length,
-          commentsCount: comments.length,
-          file: options.file
-        });
-      } else {
-        console.log(`Exported ${items.length} work items and ${comments.length} comments to ${options.file}`);
-      }
+      const filePath = options.file || dataPath;
+      const lockPath = getLockPathForJsonl(filePath);
+      withFileLock(lockPath, () => {
+        const db = utils.getDatabase(options.prefix);
+        const items = db.getAll();
+        const comments = db.getAllComments();
+        const dependencyEdges = db.getAllDependencyEdges();
+        exportToJsonl(items, comments, filePath, dependencyEdges);
+        
+        if (utils.isJsonMode()) {
+          output.json({ 
+            success: true, 
+            message: `Exported ${items.length} work items and ${comments.length} comments`,
+            itemsCount: items.length,
+            commentsCount: comments.length,
+            file: options.file
+          });
+        } else {
+          console.log(`Exported ${items.length} work items and ${comments.length} comments to ${filePath}`);
+        }
+      });
     });
 }

--- a/src/commands/import.ts
+++ b/src/commands/import.ts
@@ -5,6 +5,7 @@
 import type { PluginContext } from '../plugin-types.js';
 import type { ImportOptions } from '../cli-types.js';
 import { importFromJsonl } from '../jsonl.js';
+import { withFileLock, getLockPathForJsonl } from '../file-lock.js';
 
 export default function register(ctx: PluginContext): void {
   const { program, dataPath, output, utils } = ctx;
@@ -16,21 +17,25 @@ export default function register(ctx: PluginContext): void {
     .option('--prefix <prefix>', 'Override the default prefix')
     .action((options: ImportOptions) => {
       utils.requireInitialized();
-      const db = utils.getDatabase(options.prefix);
-      const { items, comments, dependencyEdges } = importFromJsonl(options.file || dataPath);
-      db.import(items, dependencyEdges);
-      db.importComments(comments);
-      
-      if (utils.isJsonMode()) {
-        output.json({ 
-          success: true, 
-          message: `Imported ${items.length} work items and ${comments.length} comments`,
-          itemsCount: items.length,
-          commentsCount: comments.length,
-          file: options.file
-        });
-      } else {
-        console.log(`Imported ${items.length} work items and ${comments.length} comments from ${options.file}`);
-      }
+      const filePath = options.file || dataPath;
+      const lockPath = getLockPathForJsonl(filePath);
+      withFileLock(lockPath, () => {
+        const db = utils.getDatabase(options.prefix);
+        const { items, comments, dependencyEdges } = importFromJsonl(filePath);
+        db.import(items, dependencyEdges);
+        db.importComments(comments);
+        
+        if (utils.isJsonMode()) {
+          output.json({ 
+            success: true, 
+            message: `Imported ${items.length} work items and ${comments.length} comments`,
+            itemsCount: items.length,
+            commentsCount: comments.length,
+            file: options.file
+          });
+        } else {
+          console.log(`Imported ${items.length} work items and ${comments.length} comments from ${filePath}`);
+        }
+      });
     });
 }

--- a/src/commands/sync.ts
+++ b/src/commands/sync.ts
@@ -12,6 +12,7 @@ import { importFromJsonlContent, exportToJsonl } from '../jsonl.js';
 import { loadConfig } from '../config.js';
 import { displayConflictDetails } from './helpers.js';
 import { createLogFileWriter, getWorklogLogPath, logConflictDetails } from '../logging.js';
+import { withFileLock, getLockPathForJsonl } from '../file-lock.js';
 import * as childProcess from 'child_process';
 import * as fs from 'fs';
 import { promisify } from 'util';
@@ -282,15 +283,18 @@ export default function register(ctx: PluginContext): void {
       const gitBranch = options.gitBranch || defaults.gitBranch;
       
       try {
-        await performSync(program, dataPath, utils.getDatabase, {
-          file: options.file || dataPath,
-          prefix: options.prefix,
-          gitRemote,
-          gitBranch,
-          push: options.push ?? true,
-          dryRun: options.dryRun ?? false,
-          silent: false
-        });
+        const lockPath = getLockPathForJsonl(options.file || dataPath);
+        await withFileLock(lockPath, () =>
+          performSync(program, dataPath, utils.getDatabase, {
+            file: options.file || dataPath,
+            prefix: options.prefix,
+            gitRemote,
+            gitBranch,
+            push: options.push ?? true,
+            dryRun: options.dryRun ?? false,
+            silent: false
+          })
+        );
       } catch (error) {
         if (isJsonMode) {
           output.json({

--- a/src/database.ts
+++ b/src/database.ts
@@ -9,6 +9,7 @@ import { WorkItem, CreateWorkItemInput, UpdateWorkItemInput, WorkItemQuery, Comm
 import { SqlitePersistentStore, FtsSearchResult } from './persistent-store.js';
 import { importFromJsonl, exportToJsonl, getDefaultDataPath } from './jsonl.js';
 import { mergeWorkItems, mergeComments } from './sync.js';
+import { withFileLock, getLockPathForJsonl } from './file-lock.js';
 
 const UNIQUE_TIME_LENGTH = 9;
 const UNIQUE_RANDOM_BYTES = 4;
@@ -24,6 +25,7 @@ export class WorklogDatabase {
   private silent: boolean;
   private autoSync: boolean;
   private syncProvider?: () => Promise<void>;
+  private lockPath: string;
 
   constructor(
     prefix: string = 'WI',
@@ -40,6 +42,7 @@ export class WorklogDatabase {
     this.silent = silent;
     this.autoSync = autoSync;
     this.syncProvider = syncProvider;
+    this.lockPath = getLockPathForJsonl(this.jsonlPath);
     
     // Use default DB path if not provided
     const defaultDbPath = path.join(path.dirname(this.jsonlPath), 'worklog.db');
@@ -73,27 +76,34 @@ export class WorklogDatabase {
       return; // No JSONL file, nothing to refresh from
     }
 
-    const jsonlStats = fs.statSync(this.jsonlPath);
-    const jsonlMtime = jsonlStats.mtimeMs;
+    // Hold the file lock while checking mtime and importing to prevent
+    // another process from writing between our stat and read.
+    withFileLock(this.lockPath, () => {
+      if (!fs.existsSync(this.jsonlPath)) {
+        return; // File may have been removed between our check and lock acquisition
+      }
 
-    const metadata = this.store.getAllMetadata();
-    const lastImportMtime = metadata.lastJsonlImportMtime;
-    const lastExportMtimeStr = this.store.getMetadata('lastJsonlExportMtime');
-    const lastExportMtime = lastExportMtimeStr ? Number(lastExportMtimeStr) : undefined;
+      const jsonlStats = fs.statSync(this.jsonlPath);
+      const jsonlMtime = jsonlStats.mtimeMs;
 
-    // If DB is empty or JSONL is newer, refresh from JSONL
-    const itemCount = this.store.countWorkItems();
-    // Avoid re-importing a file we just exported ourselves. If the JSONL mtime equals the
-    // last export mtime recorded in the DB, skip the refresh. Otherwise fall back to the
-    // previous logic (DB empty or JSONL newer than last import).
-    const isOurExport = lastExportMtime !== undefined && Math.abs(jsonlMtime - lastExportMtime) < 1;
-    const shouldRefresh = !isOurExport && (itemCount === 0 || !lastImportMtime || jsonlMtime > lastImportMtime);
+      const metadata = this.store.getAllMetadata();
+      const lastImportMtime = metadata.lastJsonlImportMtime;
+      const lastExportMtimeStr = this.store.getMetadata('lastJsonlExportMtime');
+      const lastExportMtime = lastExportMtimeStr ? Number(lastExportMtimeStr) : undefined;
 
-     if (shouldRefresh) {
-       if (!this.silent) {
-         // Debug: send to stderr so JSON stdout is preserved for --json mode
-         this.debug(`Refreshing database from ${this.jsonlPath}...`);
-       }
+      // If DB is empty or JSONL is newer, refresh from JSONL
+      const itemCount = this.store.countWorkItems();
+      // Avoid re-importing a file we just exported ourselves. If the JSONL mtime equals the
+      // last export mtime recorded in the DB, skip the refresh. Otherwise fall back to the
+      // previous logic (DB empty or JSONL newer than last import).
+      const isOurExport = lastExportMtime !== undefined && Math.abs(jsonlMtime - lastExportMtime) < 1;
+      const shouldRefresh = !isOurExport && (itemCount === 0 || !lastImportMtime || jsonlMtime > lastImportMtime);
+
+      if (shouldRefresh) {
+        if (!this.silent) {
+          // Debug: send to stderr so JSON stdout is preserved for --json mode
+          this.debug(`Refreshing database from ${this.jsonlPath}...`);
+        }
         const { items: jsonlItems, comments: jsonlComments, dependencyEdges } = importFromJsonl(this.jsonlPath);
         this.store.importData(jsonlItems, jsonlComments);
         for (const edge of dependencyEdges) {
@@ -101,15 +111,16 @@ export class WorklogDatabase {
             this.store.saveDependencyEdge(edge);
           }
         }
-       
-       // Update metadata
-       this.store.setMetadata('lastJsonlImportMtime', jsonlMtime.toString());
-       this.store.setMetadata('lastJsonlImportAt', new Date().toISOString());
-       
-       if (!this.silent) {
-         this.debug(`Loaded ${jsonlItems.length} work items and ${jsonlComments.length} comments from JSONL`);
-       }
-     }
+
+        // Update metadata
+        this.store.setMetadata('lastJsonlImportMtime', jsonlMtime.toString());
+        this.store.setMetadata('lastJsonlImportAt', new Date().toISOString());
+
+        if (!this.silent) {
+          this.debug(`Loaded ${jsonlItems.length} work items and ${jsonlComments.length} comments from JSONL`);
+        }
+      }
+    });
   }
 
   /**
@@ -122,38 +133,44 @@ export class WorklogDatabase {
     
     const items = this.store.getAllWorkItems();
     const comments = this.store.getAllComments();
-    let itemsToExport = items;
-    let commentsToExport = comments;
-    if (fs.existsSync(this.jsonlPath)) {
+    const dependencyEdges = this.store.getAllDependencyEdges();
+
+    // Hold the file lock for the entire read-merge-write cycle to prevent
+    // another process from reading a partially-written file or interleaving
+    // its own merge while we are writing.
+    withFileLock(this.lockPath, () => {
+      let itemsToExport = items;
+      let commentsToExport = comments;
+      if (fs.existsSync(this.jsonlPath)) {
+        try {
+          const { items: diskItems, comments: diskComments } = importFromJsonl(this.jsonlPath);
+          const itemMergeResult = mergeWorkItems(items, diskItems);
+          const commentMergeResult = mergeComments(comments, diskComments);
+          itemsToExport = itemMergeResult.merged;
+          commentsToExport = commentMergeResult.merged;
+        } catch (error) {
+          if (!this.silent) {
+            const message = error instanceof Error ? error.message : String(error);
+            this.debug(`WorklogDatabase.exportToJsonl: merge failed, exporting local snapshot. ${message}`);
+          }
+        }
+      }
+      if (!this.silent) {
+        // Debug: use stderr for diagnostic logs
+        this.debug(`WorklogDatabase.exportToJsonl: exporting ${itemsToExport.length} items and ${commentsToExport.length} comments to ${this.jsonlPath}`);
+      }
       try {
-        const { items: diskItems, comments: diskComments } = importFromJsonl(this.jsonlPath);
-        const itemMergeResult = mergeWorkItems(items, diskItems);
-        const commentMergeResult = mergeComments(comments, diskComments);
-        itemsToExport = itemMergeResult.merged;
-        commentsToExport = commentMergeResult.merged;
+        const mtime = exportToJsonl(itemsToExport, commentsToExport, this.jsonlPath, dependencyEdges);
+        // Record export mtime so other processes can avoid re-importing our own export
+        this.store.setMetadata('lastJsonlExportMtime', String(Math.floor(mtime)));
+        this.store.setMetadata('lastJsonlExportAt', new Date().toISOString());
       } catch (error) {
         if (!this.silent) {
           const message = error instanceof Error ? error.message : String(error);
-          this.debug(`WorklogDatabase.exportToJsonl: merge failed, exporting local snapshot. ${message}`);
+          this.debug(`WorklogDatabase.exportToJsonl: failed to write JSONL: ${message}`);
         }
       }
-    }
-    if (!this.silent) {
-      // Debug: use stderr for diagnostic logs
-      this.debug(`WorklogDatabase.exportToJsonl: exporting ${itemsToExport.length} items and ${commentsToExport.length} comments to ${this.jsonlPath}`);
-    }
-    const dependencyEdges = this.store.getAllDependencyEdges();
-    try {
-      const mtime = exportToJsonl(itemsToExport, commentsToExport, this.jsonlPath, dependencyEdges);
-      // Record export mtime so other processes can avoid re-importing our own export
-      this.store.setMetadata('lastJsonlExportMtime', String(Math.floor(mtime)));
-      this.store.setMetadata('lastJsonlExportAt', new Date().toISOString());
-    } catch (error) {
-      if (!this.silent) {
-        const message = error instanceof Error ? error.message : String(error);
-        this.debug(`WorklogDatabase.exportToJsonl: failed to write JSONL: ${message}`);
-      }
-    }
+    });
   }
 
   private debug(message: string): void {

--- a/src/file-lock.ts
+++ b/src/file-lock.ts
@@ -1,0 +1,333 @@
+/**
+ * File-based mutex for serializing access to the JSONL data file.
+ *
+ * Uses an advisory lock file created with O_CREAT | O_EXCL (atomic
+ * create-if-not-exists) to ensure only one process at a time can
+ * perform read-merge-write operations on the shared data file.
+ *
+ * The lock file contains the holder's PID, hostname, and acquisition
+ * timestamp so that stale locks left behind by crashed processes can
+ * be detected and cleaned up automatically.
+ */
+
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export interface FileLockOptions {
+  /** Maximum number of acquisition attempts before giving up (default 50). */
+  retries?: number;
+  /** Delay in milliseconds between retry attempts (default 100). */
+  retryDelay?: number;
+  /** Overall timeout in milliseconds (default 10 000). Takes precedence over retries × retryDelay. */
+  timeout?: number;
+  /** If true, stale locks from dead processes are automatically removed (default true). */
+  staleLockCleanup?: boolean;
+}
+
+export interface FileLockInfo {
+  pid: number;
+  hostname: string;
+  acquiredAt: string; // ISO-8601
+}
+
+// ---------------------------------------------------------------------------
+// Defaults
+// ---------------------------------------------------------------------------
+
+const DEFAULT_RETRIES = 50;
+const DEFAULT_RETRY_DELAY_MS = 100;
+const DEFAULT_TIMEOUT_MS = 10_000;
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Derive the lock file path for a given JSONL data file path.
+ *
+ * Example: `/path/to/.worklog/worklog-data.jsonl` → `/path/to/.worklog/worklog-data.jsonl.lock`
+ */
+export function getLockPathForJsonl(jsonlPath: string): string {
+  return `${jsonlPath}.lock`;
+}
+
+/**
+ * Check whether a process with the given PID is still running.
+ * Uses `process.kill(pid, 0)` which sends signal 0 (no-op) — it
+ * throws ESRCH if the process does not exist, and EPERM if we
+ * lack permission (but the process *does* exist).
+ */
+function isProcessAlive(pid: number): boolean {
+  try {
+    process.kill(pid, 0);
+    return true; // signal sent successfully — process is alive
+  } catch (err: any) {
+    if (err.code === 'ESRCH') {
+      return false; // no such process
+    }
+    // EPERM means the process exists but we can't signal it — treat as alive
+    return true;
+  }
+}
+
+/**
+ * Try to read and parse lock file contents.  Returns null if the file
+ * does not exist or cannot be parsed.
+ */
+function readLockInfo(lockPath: string): FileLockInfo | null {
+  try {
+    const content = fs.readFileSync(lockPath, 'utf-8');
+    const info = JSON.parse(content) as FileLockInfo;
+    if (typeof info.pid === 'number' && typeof info.hostname === 'string') {
+      return info;
+    }
+    return null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Synchronous sleep using a busy-wait loop.  Used during retry loops
+ * where we intentionally want to block the event loop (the entire
+ * codebase is synchronous I/O).
+ */
+function sleepSync(ms: number): void {
+  const end = Date.now() + ms;
+  while (Date.now() < end) {
+    // busy-wait
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Reentrancy tracking
+// ---------------------------------------------------------------------------
+
+/**
+ * Per-path counter tracking how many times the current process has acquired
+ * a lock via `withFileLock`.  When the counter is > 0 for a given path the
+ * process already owns the lock and nested calls to `withFileLock` become
+ * transparent pass-throughs (no acquire / release).
+ *
+ * This is safe because Node.js is single-threaded — the map is only accessed
+ * from the same event-loop turn that called `withFileLock`.
+ */
+const heldLocks: Map<string, number> = new Map();
+
+/**
+ * Resolve a lock path to its canonical (absolute, real) form so that
+ * different relative references to the same file share one counter.
+ */
+function canonicalLockPath(lockPath: string): string {
+  return path.resolve(lockPath);
+}
+
+// ---------------------------------------------------------------------------
+// Core API
+// ---------------------------------------------------------------------------
+
+/**
+ * Attempt to acquire a file lock at `lockPath`.
+ *
+ * On success the lock file is created (atomically via `O_EXCL`) and
+ * populated with the current process's PID, hostname, and timestamp.
+ *
+ * On failure (lock already held by a live process and retries exhausted)
+ * an error is thrown.
+ */
+export function acquireFileLock(lockPath: string, options?: FileLockOptions): void {
+  const retries = options?.retries ?? DEFAULT_RETRIES;
+  const retryDelay = options?.retryDelay ?? DEFAULT_RETRY_DELAY_MS;
+  const timeout = options?.timeout ?? DEFAULT_TIMEOUT_MS;
+  const staleLockCleanup = options?.staleLockCleanup ?? true;
+
+  const deadline = Date.now() + timeout;
+
+  const lockInfo: FileLockInfo = {
+    pid: process.pid,
+    hostname: os.hostname(),
+    acquiredAt: new Date().toISOString(),
+  };
+  const lockContent = JSON.stringify(lockInfo);
+
+  // Ensure the parent directory exists
+  const lockDir = path.dirname(lockPath);
+  if (!fs.existsSync(lockDir)) {
+    fs.mkdirSync(lockDir, { recursive: true });
+  }
+
+  for (let attempt = 0; attempt <= retries; attempt++) {
+    // Check timeout
+    if (Date.now() > deadline) {
+      const existingInfo = readLockInfo(lockPath);
+      const holder = existingInfo
+        ? `held by PID ${existingInfo.pid} on ${existingInfo.hostname} since ${existingInfo.acquiredAt}`
+        : 'unknown holder';
+      throw new Error(
+        `Failed to acquire file lock at ${lockPath} after ${timeout}ms timeout (${holder})`
+      );
+    }
+
+    try {
+      // O_CREAT | O_EXCL | O_WRONLY — atomic create-if-not-exists
+      const fd = fs.openSync(lockPath, fs.constants.O_CREAT | fs.constants.O_EXCL | fs.constants.O_WRONLY);
+      fs.writeSync(fd, lockContent);
+      fs.closeSync(fd);
+      return; // lock acquired
+    } catch (err: any) {
+      if (err.code !== 'EEXIST') {
+        // Unexpected error (permissions, disk full, etc.)
+        throw new Error(`Failed to create lock file at ${lockPath}: ${err.message}`);
+      }
+
+      // Lock file already exists — check for stale lock
+      if (staleLockCleanup) {
+        const existing = readLockInfo(lockPath);
+        if (existing) {
+          const sameHost = existing.hostname === os.hostname();
+          if (sameHost && !isProcessAlive(existing.pid)) {
+            // Stale lock from a dead process on this host — remove it
+            try {
+              fs.unlinkSync(lockPath);
+              // Don't increment attempt counter; retry immediately
+              continue;
+            } catch {
+              // Another process may have removed it; retry
+              continue;
+            }
+          }
+        }
+      }
+
+      // Lock is held by a live process (or on another host) — wait and retry
+      if (attempt < retries) {
+        const remaining = deadline - Date.now();
+        if (remaining <= 0) {
+          // Will be caught by the timeout check at the top of the loop
+          continue;
+        }
+        sleepSync(Math.min(retryDelay, remaining));
+      }
+    }
+  }
+
+  // Exhausted all retries
+  const existingInfo = readLockInfo(lockPath);
+  const holder = existingInfo
+    ? `held by PID ${existingInfo.pid} on ${existingInfo.hostname} since ${existingInfo.acquiredAt}`
+    : 'unknown holder';
+  throw new Error(
+    `Failed to acquire file lock at ${lockPath} after ${retries} retries (${holder})`
+  );
+}
+
+/**
+ * Release a previously acquired file lock by removing the lock file.
+ * It is safe to call this even if the lock file does not exist (no-op).
+ */
+export function releaseFileLock(lockPath: string): void {
+  try {
+    fs.unlinkSync(lockPath);
+  } catch (err: any) {
+    if (err.code !== 'ENOENT') {
+      // If the file doesn't exist, that's fine — lock was already released.
+      // Any other error is unexpected.
+      throw new Error(`Failed to release file lock at ${lockPath}: ${err.message}`);
+    }
+  }
+}
+
+/**
+ * Execute `fn` while holding the file lock at `lockPath`.
+ *
+ * The lock is acquired before `fn` is called and released in a
+ * `finally` block — even if `fn` throws.  Supports both synchronous
+ * and asynchronous callbacks.
+ *
+ * **Reentrancy:** If the current process already holds the lock for
+ * `lockPath` (via a surrounding `withFileLock` call), the nested
+ * invocation is a transparent pass-through — `fn` runs immediately
+ * without touching the lock file.
+ */
+export function withFileLock<T>(
+  lockPath: string,
+  fn: () => T,
+  options?: FileLockOptions
+): T {
+  const canonical = canonicalLockPath(lockPath);
+  const depth = heldLocks.get(canonical) ?? 0;
+
+  if (depth > 0) {
+    // Already holding this lock — reentrant call, just run fn.
+    heldLocks.set(canonical, depth + 1);
+    try {
+      const result = fn();
+      if (result instanceof Promise) {
+        return result.then(
+          (value) => {
+            heldLocks.set(canonical, (heldLocks.get(canonical) ?? 1) - 1);
+            return value;
+          },
+          (err) => {
+            heldLocks.set(canonical, (heldLocks.get(canonical) ?? 1) - 1);
+            throw err;
+          }
+        ) as T;
+      }
+      heldLocks.set(canonical, depth);
+      return result;
+    } catch (err) {
+      heldLocks.set(canonical, depth);
+      throw err;
+    }
+  }
+
+  // First acquisition — acquire the file lock.
+  acquireFileLock(lockPath, options);
+  heldLocks.set(canonical, 1);
+  try {
+    const result = fn();
+    // If fn returns a promise, chain the release onto it
+    if (result instanceof Promise) {
+      return result.then(
+        (value) => {
+          heldLocks.delete(canonical);
+          releaseFileLock(lockPath);
+          return value;
+        },
+        (err) => {
+          heldLocks.delete(canonical);
+          releaseFileLock(lockPath);
+          throw err;
+        }
+      ) as T;
+    }
+    heldLocks.delete(canonical);
+    releaseFileLock(lockPath);
+    return result;
+  } catch (err) {
+    heldLocks.delete(canonical);
+    releaseFileLock(lockPath);
+    throw err;
+  }
+}
+
+/**
+ * Check whether the current process holds the file lock at `lockPath`.
+ * Useful for testing and diagnostics.
+ */
+export function isFileLockHeld(lockPath: string): boolean {
+  return (heldLocks.get(canonicalLockPath(lockPath)) ?? 0) > 0;
+}
+
+/**
+ * Reset reentrancy tracking (for use in tests only).
+ */
+export function _resetLockState(): void {
+  heldLocks.clear();
+}

--- a/tests/file-lock.test.ts
+++ b/tests/file-lock.test.ts
@@ -1,0 +1,735 @@
+/**
+ * Tests for file-lock module
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import * as fs from 'fs';
+import * as path from 'path';
+import * as os from 'os';
+import * as childProcess from 'child_process';
+import { acquireFileLock, releaseFileLock, withFileLock, getLockPathForJsonl, isFileLockHeld, _resetLockState } from '../src/file-lock.js';
+import type { FileLockInfo } from '../src/file-lock.js';
+import { createTempDir, cleanupTempDir } from './test-utils.js';
+
+describe('file-lock', () => {
+  let tempDir: string;
+  let lockPath: string;
+
+  beforeEach(() => {
+    tempDir = createTempDir();
+    lockPath = path.join(tempDir, 'test.lock');
+  });
+
+  afterEach(() => {
+    // Reset reentrancy state between tests
+    _resetLockState();
+    // Clean up any leftover lock files
+    try { fs.unlinkSync(lockPath); } catch { /* ignore */ }
+    cleanupTempDir(tempDir);
+  });
+
+  describe('getLockPathForJsonl', () => {
+    it('should append .lock to the JSONL path', () => {
+      expect(getLockPathForJsonl('/path/to/worklog-data.jsonl')).toBe('/path/to/worklog-data.jsonl.lock');
+    });
+
+    it('should work with relative paths', () => {
+      expect(getLockPathForJsonl('data.jsonl')).toBe('data.jsonl.lock');
+    });
+  });
+
+  describe('acquireFileLock', () => {
+    it('should create a lock file with PID, hostname, and timestamp', () => {
+      acquireFileLock(lockPath, { retries: 0, timeout: 1000 });
+
+      expect(fs.existsSync(lockPath)).toBe(true);
+      const content = fs.readFileSync(lockPath, 'utf-8');
+      const info: FileLockInfo = JSON.parse(content);
+
+      expect(info.pid).toBe(process.pid);
+      expect(info.hostname).toBe(os.hostname());
+      expect(info.acquiredAt).toBeDefined();
+      // Verify it's a valid ISO date
+      expect(new Date(info.acquiredAt).toISOString()).toBe(info.acquiredAt);
+
+      // Clean up
+      releaseFileLock(lockPath);
+    });
+
+    it('should fail immediately when lock is held and retries=0', () => {
+      // Create a lock file manually (simulating another process holding it)
+      const otherLockInfo: FileLockInfo = {
+        pid: process.pid, // Use current PID so it's seen as alive
+        hostname: os.hostname(),
+        acquiredAt: new Date().toISOString(),
+      };
+      fs.writeFileSync(lockPath, JSON.stringify(otherLockInfo));
+
+      expect(() => {
+        acquireFileLock(lockPath, { retries: 0, timeout: 100 });
+      }).toThrow(/Failed to acquire file lock/);
+    });
+
+    it('should succeed after a stale lock from a dead process is cleaned up', () => {
+      // Create a lock file with a non-existent PID
+      const staleLockInfo: FileLockInfo = {
+        pid: 999999, // Very unlikely to be a real PID
+        hostname: os.hostname(),
+        acquiredAt: new Date().toISOString(),
+      };
+      fs.writeFileSync(lockPath, JSON.stringify(staleLockInfo));
+
+      // Should succeed because the stale lock is detected and removed
+      acquireFileLock(lockPath, { retries: 1, timeout: 5000 });
+
+      // Verify our lock is now in place
+      const content = fs.readFileSync(lockPath, 'utf-8');
+      const info: FileLockInfo = JSON.parse(content);
+      expect(info.pid).toBe(process.pid);
+
+      releaseFileLock(lockPath);
+    });
+
+    it('should not clean up stale locks from different hosts', () => {
+      // Create a lock file from a "different host"
+      const remoteLockInfo: FileLockInfo = {
+        pid: 999999,
+        hostname: 'some-other-host-that-is-not-this-one',
+        acquiredAt: new Date().toISOString(),
+      };
+      fs.writeFileSync(lockPath, JSON.stringify(remoteLockInfo));
+
+      // Should fail because we can't verify the PID on a different host
+      expect(() => {
+        acquireFileLock(lockPath, { retries: 0, timeout: 100 });
+      }).toThrow(/Failed to acquire file lock/);
+    });
+
+    it('should respect the timeout option', () => {
+      // Create a lock held by the current process
+      const lockInfo: FileLockInfo = {
+        pid: process.pid,
+        hostname: os.hostname(),
+        acquiredAt: new Date().toISOString(),
+      };
+      fs.writeFileSync(lockPath, JSON.stringify(lockInfo));
+
+      const start = Date.now();
+      expect(() => {
+        acquireFileLock(lockPath, { retries: 100, retryDelay: 50, timeout: 300 });
+      }).toThrow(/timeout/);
+      const elapsed = Date.now() - start;
+
+      // Should have waited approximately the timeout duration
+      expect(elapsed).toBeGreaterThanOrEqual(250); // Allow some slack
+      expect(elapsed).toBeLessThan(2000); // But not too long
+    });
+
+    it('should create parent directories if they do not exist', () => {
+      const deepLockPath = path.join(tempDir, 'a', 'b', 'c', 'test.lock');
+
+      acquireFileLock(deepLockPath, { retries: 0, timeout: 1000 });
+      expect(fs.existsSync(deepLockPath)).toBe(true);
+
+      releaseFileLock(deepLockPath);
+    });
+
+    it('should throw on unexpected filesystem errors', () => {
+      // Try to acquire a lock in a path that cannot be created
+      // (e.g. a file where a directory is expected)
+      const filePath = path.join(tempDir, 'not-a-dir');
+      fs.writeFileSync(filePath, 'block');
+      const badLockPath = path.join(filePath, 'test.lock');
+
+      expect(() => {
+        acquireFileLock(badLockPath, { retries: 0, timeout: 1000 });
+      }).toThrow();
+    });
+  });
+
+  describe('releaseFileLock', () => {
+    it('should remove the lock file', () => {
+      fs.writeFileSync(lockPath, JSON.stringify({ pid: process.pid, hostname: os.hostname(), acquiredAt: new Date().toISOString() }));
+      expect(fs.existsSync(lockPath)).toBe(true);
+
+      releaseFileLock(lockPath);
+      expect(fs.existsSync(lockPath)).toBe(false);
+    });
+
+    it('should be a no-op if the lock file does not exist', () => {
+      expect(fs.existsSync(lockPath)).toBe(false);
+      // Should not throw
+      releaseFileLock(lockPath);
+    });
+  });
+
+  describe('withFileLock', () => {
+    it('should acquire the lock, run the callback, and release the lock', () => {
+      let callbackRan = false;
+
+      withFileLock(lockPath, () => {
+        // Verify lock is held during callback
+        expect(fs.existsSync(lockPath)).toBe(true);
+        callbackRan = true;
+      });
+
+      expect(callbackRan).toBe(true);
+      // Verify lock is released after callback
+      expect(fs.existsSync(lockPath)).toBe(false);
+    });
+
+    it('should return the callback result', () => {
+      const result = withFileLock(lockPath, () => 42);
+      expect(result).toBe(42);
+    });
+
+    it('should release the lock even if the callback throws', () => {
+      expect(() => {
+        withFileLock(lockPath, () => {
+          expect(fs.existsSync(lockPath)).toBe(true);
+          throw new Error('callback error');
+        });
+      }).toThrow('callback error');
+
+      // Lock should be released
+      expect(fs.existsSync(lockPath)).toBe(false);
+    });
+
+    it('should handle async callbacks and release lock after resolution', async () => {
+      const result = await withFileLock(lockPath, async () => {
+        expect(fs.existsSync(lockPath)).toBe(true);
+        return 'async-result';
+      });
+
+      expect(result).toBe('async-result');
+      expect(fs.existsSync(lockPath)).toBe(false);
+    });
+
+    it('should release lock after async callback rejection', async () => {
+      await expect(
+        withFileLock(lockPath, async () => {
+          expect(fs.existsSync(lockPath)).toBe(true);
+          throw new Error('async error');
+        })
+      ).rejects.toThrow('async error');
+
+      expect(fs.existsSync(lockPath)).toBe(false);
+    });
+
+    it('should serialize access when called sequentially', () => {
+      const order: number[] = [];
+
+      withFileLock(lockPath, () => {
+        order.push(1);
+      });
+
+      withFileLock(lockPath, () => {
+        order.push(2);
+      });
+
+      withFileLock(lockPath, () => {
+        order.push(3);
+      });
+
+      expect(order).toEqual([1, 2, 3]);
+    });
+
+    it('should pass through options to acquireFileLock', () => {
+      // Hold the lock manually
+      const lockInfo: FileLockInfo = {
+        pid: process.pid,
+        hostname: os.hostname(),
+        acquiredAt: new Date().toISOString(),
+      };
+      fs.writeFileSync(lockPath, JSON.stringify(lockInfo));
+
+      expect(() => {
+        withFileLock(lockPath, () => {}, { retries: 0, timeout: 100 });
+      }).toThrow(/Failed to acquire file lock/);
+    });
+  });
+
+  describe('retry logic', () => {
+    it('should eventually acquire the lock after it is released', () => {
+      // Acquire the lock
+      acquireFileLock(lockPath, { retries: 0, timeout: 1000 });
+
+      // Schedule release after a short delay
+      const releaseAfterMs = 200;
+      setTimeout(() => {
+        releaseFileLock(lockPath);
+      }, releaseAfterMs);
+
+      // Try to acquire in a new "process" context (same process, so we need
+      // a different lock path or release first). Since we're in the same
+      // process and the lock contains our PID, we simulate by writing a lock
+      // with a fake alive PID then releasing it.
+
+      // Actually, let's test this differently — release the current lock
+      // and verify re-acquisition works
+      releaseFileLock(lockPath);
+
+      // Re-acquire should succeed immediately
+      acquireFileLock(lockPath, { retries: 0, timeout: 1000 });
+      expect(fs.existsSync(lockPath)).toBe(true);
+      releaseFileLock(lockPath);
+    });
+  });
+
+  describe('stale lock cleanup', () => {
+    it('should clean up and re-acquire a stale lock from a dead process', () => {
+      // Write a lock file with a non-existent PID
+      const stalePid = 999999;
+      const staleInfo: FileLockInfo = {
+        pid: stalePid,
+        hostname: os.hostname(),
+        acquiredAt: new Date(Date.now() - 60000).toISOString(), // 1 minute ago
+      };
+      fs.writeFileSync(lockPath, JSON.stringify(staleInfo));
+
+      // Acquire should succeed (stale lock cleaned up)
+      acquireFileLock(lockPath, { retries: 1, timeout: 5000 });
+
+      const content = fs.readFileSync(lockPath, 'utf-8');
+      const info: FileLockInfo = JSON.parse(content);
+      expect(info.pid).toBe(process.pid);
+
+      releaseFileLock(lockPath);
+    });
+
+    it('should not clean up stale locks when staleLockCleanup is false', () => {
+      const staleInfo: FileLockInfo = {
+        pid: 999999,
+        hostname: os.hostname(),
+        acquiredAt: new Date().toISOString(),
+      };
+      fs.writeFileSync(lockPath, JSON.stringify(staleInfo));
+
+      expect(() => {
+        acquireFileLock(lockPath, { retries: 0, timeout: 100, staleLockCleanup: false });
+      }).toThrow(/Failed to acquire file lock/);
+    });
+
+    it('should handle corrupted lock file content gracefully', () => {
+      // Write garbage content to the lock file
+      fs.writeFileSync(lockPath, 'not-json-content');
+
+      // Should fail (can't parse lock info, can't determine if stale)
+      expect(() => {
+        acquireFileLock(lockPath, { retries: 0, timeout: 100 });
+      }).toThrow(/Failed to acquire file lock/);
+    });
+  });
+
+  describe('reentrancy', () => {
+    it('should allow nested withFileLock calls on the same path without deadlocking', () => {
+      const order: string[] = [];
+
+      withFileLock(lockPath, () => {
+        order.push('outer-start');
+        expect(isFileLockHeld(lockPath)).toBe(true);
+
+        // Nested call on the same lock path — must not deadlock
+        withFileLock(lockPath, () => {
+          order.push('inner');
+          expect(isFileLockHeld(lockPath)).toBe(true);
+        });
+
+        order.push('outer-end');
+        expect(isFileLockHeld(lockPath)).toBe(true);
+      });
+
+      expect(order).toEqual(['outer-start', 'inner', 'outer-end']);
+      // Lock should be fully released after outermost withFileLock returns
+      expect(isFileLockHeld(lockPath)).toBe(false);
+      expect(fs.existsSync(lockPath)).toBe(false);
+    });
+
+    it('should track reentrancy depth correctly across three nesting levels', () => {
+      let depths: boolean[] = [];
+
+      withFileLock(lockPath, () => {
+        depths.push(isFileLockHeld(lockPath)); // true (depth 1)
+
+        withFileLock(lockPath, () => {
+          depths.push(isFileLockHeld(lockPath)); // true (depth 2)
+
+          withFileLock(lockPath, () => {
+            depths.push(isFileLockHeld(lockPath)); // true (depth 3)
+          });
+
+          depths.push(isFileLockHeld(lockPath)); // true (depth 2 again)
+        });
+
+        depths.push(isFileLockHeld(lockPath)); // true (depth 1 again)
+      });
+
+      // All checks should be true while inside withFileLock
+      expect(depths).toEqual([true, true, true, true, true]);
+      // After outermost exits, lock should be released
+      expect(isFileLockHeld(lockPath)).toBe(false);
+    });
+
+    it('should release lock file only when outermost withFileLock exits', () => {
+      withFileLock(lockPath, () => {
+        // Lock file should exist on disk (outer acquired it)
+        expect(fs.existsSync(lockPath)).toBe(true);
+
+        withFileLock(lockPath, () => {
+          // Still exists — inner didn't touch it
+          expect(fs.existsSync(lockPath)).toBe(true);
+        });
+
+        // Inner returned but lock file should still exist (outer still holds it)
+        expect(fs.existsSync(lockPath)).toBe(true);
+      });
+
+      // Now outer returned — lock file should be gone
+      expect(fs.existsSync(lockPath)).toBe(false);
+    });
+
+    it('should clean up reentrancy state if inner callback throws', () => {
+      expect(() => {
+        withFileLock(lockPath, () => {
+          withFileLock(lockPath, () => {
+            throw new Error('inner error');
+          });
+        });
+      }).toThrow('inner error');
+
+      // Reentrancy state should be fully cleaned up
+      expect(isFileLockHeld(lockPath)).toBe(false);
+      expect(fs.existsSync(lockPath)).toBe(false);
+    });
+
+    it('should clean up reentrancy state if outer callback throws after successful inner', () => {
+      expect(() => {
+        withFileLock(lockPath, () => {
+          withFileLock(lockPath, () => {
+            // inner succeeds
+          });
+          throw new Error('outer error');
+        });
+      }).toThrow('outer error');
+
+      expect(isFileLockHeld(lockPath)).toBe(false);
+      expect(fs.existsSync(lockPath)).toBe(false);
+    });
+
+    it('should handle async nested withFileLock calls', async () => {
+      const order: string[] = [];
+
+      await withFileLock(lockPath, async () => {
+        order.push('outer-start');
+
+        await withFileLock(lockPath, async () => {
+          order.push('inner');
+        });
+
+        order.push('outer-end');
+      });
+
+      expect(order).toEqual(['outer-start', 'inner', 'outer-end']);
+      expect(isFileLockHeld(lockPath)).toBe(false);
+      expect(fs.existsSync(lockPath)).toBe(false);
+    });
+
+    it('should clean up reentrancy state on async inner rejection', async () => {
+      await expect(
+        withFileLock(lockPath, async () => {
+          await withFileLock(lockPath, async () => {
+            throw new Error('async inner error');
+          });
+        })
+      ).rejects.toThrow('async inner error');
+
+      expect(isFileLockHeld(lockPath)).toBe(false);
+      expect(fs.existsSync(lockPath)).toBe(false);
+    });
+
+    it('should treat different lock paths independently', () => {
+      const lockPath2 = path.join(tempDir, 'test2.lock');
+
+      withFileLock(lockPath, () => {
+        expect(isFileLockHeld(lockPath)).toBe(true);
+        expect(isFileLockHeld(lockPath2)).toBe(false);
+
+        withFileLock(lockPath2, () => {
+          expect(isFileLockHeld(lockPath)).toBe(true);
+          expect(isFileLockHeld(lockPath2)).toBe(true);
+        });
+
+        expect(isFileLockHeld(lockPath2)).toBe(false);
+        expect(isFileLockHeld(lockPath)).toBe(true);
+      });
+
+      expect(isFileLockHeld(lockPath)).toBe(false);
+      expect(isFileLockHeld(lockPath2)).toBe(false);
+
+      // Clean up
+      try { fs.unlinkSync(lockPath2); } catch { /* ignore */ }
+    });
+
+    it('should return values from nested withFileLock calls', () => {
+      const result = withFileLock(lockPath, () => {
+        const inner = withFileLock(lockPath, () => {
+          return 'inner-value';
+        });
+        return `outer-${inner}`;
+      });
+
+      expect(result).toBe('outer-inner-value');
+    });
+
+    it('should treat relative and absolute paths to the same file as one lock', () => {
+      // Use the absolute lockPath and a relative version of the same path
+      const cwd = process.cwd();
+      const relativeLockPath = path.relative(cwd, lockPath);
+
+      withFileLock(lockPath, () => {
+        expect(isFileLockHeld(lockPath)).toBe(true);
+
+        // Nested call with the relative path — should be treated as reentrant
+        withFileLock(relativeLockPath, () => {
+          expect(isFileLockHeld(relativeLockPath)).toBe(true);
+        });
+
+        // Lock should still be held (outer hasn't returned)
+        expect(isFileLockHeld(lockPath)).toBe(true);
+        expect(fs.existsSync(lockPath)).toBe(true);
+      });
+
+      expect(isFileLockHeld(lockPath)).toBe(false);
+    });
+  });
+
+  describe('isFileLockHeld', () => {
+    it('should return false when no lock is held', () => {
+      expect(isFileLockHeld(lockPath)).toBe(false);
+    });
+
+    it('should return true inside withFileLock', () => {
+      withFileLock(lockPath, () => {
+        expect(isFileLockHeld(lockPath)).toBe(true);
+      });
+    });
+
+    it('should return false after withFileLock completes', () => {
+      withFileLock(lockPath, () => {});
+      expect(isFileLockHeld(lockPath)).toBe(false);
+    });
+  });
+
+  describe('_resetLockState', () => {
+    it('should clear all tracked reentrancy state', () => {
+      withFileLock(lockPath, () => {
+        expect(isFileLockHeld(lockPath)).toBe(true);
+        // Simulate an abnormal situation: reset while lock is held
+        _resetLockState();
+        expect(isFileLockHeld(lockPath)).toBe(false);
+      });
+      // Note: the outer withFileLock will still release the file on disk
+    });
+  });
+
+  describe('concurrent multi-process access', () => {
+    /**
+     * Helper script that each child process runs.
+     * It acquires the lock, reads a counter from a shared file, increments it,
+     * writes it back, and releases the lock.
+     *
+     * Without the lock, concurrent processes would lose increments (TOCTOU race).
+     * With the lock, the final counter value must equal the number of increments.
+     */
+    function createWorkerScript(dir: string): string {
+      const scriptPath = path.join(dir, 'lock-worker.mjs');
+      const script = `
+import * as fs from 'fs';
+import * as path from 'path';
+
+// Import the compiled file-lock module
+const fileLock = await import(path.resolve(process.argv[2]));
+
+const lockPath = process.argv[3];
+const counterFile = process.argv[4];
+const iterations = parseInt(process.argv[5], 10);
+
+for (let i = 0; i < iterations; i++) {
+  fileLock.withFileLock(lockPath, () => {
+    // Read current counter
+    let counter = 0;
+    try {
+      counter = parseInt(fs.readFileSync(counterFile, 'utf-8'), 10);
+      if (isNaN(counter)) counter = 0;
+    } catch {
+      counter = 0;
+    }
+
+    // Increment and write back
+    counter++;
+    fs.writeFileSync(counterFile, String(counter));
+  }, { retries: 200, retryDelay: 10, timeout: 30000 });
+}
+
+// Signal success
+process.exit(0);
+`;
+      fs.writeFileSync(scriptPath, script);
+      return scriptPath;
+    }
+
+    it('should serialize writes across multiple processes (no lost increments)', () => {
+      const workerScript = createWorkerScript(tempDir);
+      const counterFile = path.join(tempDir, 'counter.txt');
+      const sharedLockPath = path.join(tempDir, 'shared.lock');
+
+      // Initialize counter
+      fs.writeFileSync(counterFile, '0');
+
+      const numWorkers = 4;
+      const iterationsPerWorker = 10;
+
+      // Find the compiled file-lock module
+      const fileLockModulePath = path.resolve(__dirname, '..', 'dist', 'file-lock.js');
+
+      // If dist doesn't exist (not built), skip this test gracefully
+      if (!fs.existsSync(fileLockModulePath)) {
+        // Try using tsx to run the TypeScript source directly
+        const fileLockTsPath = path.resolve(__dirname, '..', 'src', 'file-lock.ts');
+
+        // Spawn workers using tsx
+        const workers: childProcess.SpawnSyncReturns<string>[] = [];
+
+        for (let i = 0; i < numWorkers; i++) {
+          const result = childProcess.spawnSync(
+            process.execPath,
+            [
+              '--import', 'tsx',
+              workerScript,
+              fileLockTsPath,
+              sharedLockPath,
+              counterFile,
+              String(iterationsPerWorker),
+            ],
+            {
+              encoding: 'utf-8',
+              timeout: 60000,
+              env: { ...process.env, NODE_NO_WARNINGS: '1' },
+            }
+          );
+          workers.push(result);
+        }
+
+        // All workers must exit successfully
+        for (let i = 0; i < workers.length; i++) {
+          if (workers[i].status !== 0) {
+            console.error(`Worker ${i} failed:`, workers[i].stderr);
+          }
+          expect(workers[i].status).toBe(0);
+        }
+
+        // The final counter value must equal numWorkers * iterationsPerWorker
+        const finalCounter = parseInt(fs.readFileSync(counterFile, 'utf-8'), 10);
+        expect(finalCounter).toBe(numWorkers * iterationsPerWorker);
+        return;
+      }
+
+      // Spawn workers using the compiled JS module
+      const workers: childProcess.SpawnSyncReturns<string>[] = [];
+
+      for (let i = 0; i < numWorkers; i++) {
+        const result = childProcess.spawnSync(
+          process.execPath,
+          [
+            workerScript,
+            fileLockModulePath,
+            sharedLockPath,
+            counterFile,
+            String(iterationsPerWorker),
+          ],
+          {
+            encoding: 'utf-8',
+            timeout: 60000,
+            env: { ...process.env, NODE_NO_WARNINGS: '1' },
+          }
+        );
+        workers.push(result);
+      }
+
+      // All workers must exit successfully
+      for (let i = 0; i < workers.length; i++) {
+        if (workers[i].status !== 0) {
+          console.error(`Worker ${i} failed:`, workers[i].stderr);
+        }
+        expect(workers[i].status).toBe(0);
+      }
+
+      // The final counter value must equal numWorkers * iterationsPerWorker
+      const finalCounter = parseInt(fs.readFileSync(counterFile, 'utf-8'), 10);
+      expect(finalCounter).toBe(numWorkers * iterationsPerWorker);
+    }, 60000); // 60s timeout for this test
+
+    it('should serialize writes when workers run concurrently (parallel spawn)', async () => {
+      const workerScript = createWorkerScript(tempDir);
+      const counterFile = path.join(tempDir, 'counter-parallel.txt');
+      const sharedLockPath = path.join(tempDir, 'shared-parallel.lock');
+
+      // Initialize counter
+      fs.writeFileSync(counterFile, '0');
+
+      const numWorkers = 4;
+      const iterationsPerWorker = 10;
+
+      // Determine module path
+      const fileLockModulePath = path.resolve(__dirname, '..', 'dist', 'file-lock.js');
+      const fileLockTsPath = path.resolve(__dirname, '..', 'src', 'file-lock.ts');
+      const useTs = !fs.existsSync(fileLockModulePath);
+      const modulePath = useTs ? fileLockTsPath : fileLockModulePath;
+
+      // Spawn all workers in parallel and wait for them via promises
+      const workerPromises: Promise<{ index: number; exitCode: number | null; stderr: string }>[] = [];
+
+      for (let i = 0; i < numWorkers; i++) {
+        const args = useTs
+          ? ['--import', 'tsx', workerScript, modulePath, sharedLockPath, counterFile, String(iterationsPerWorker)]
+          : [workerScript, modulePath, sharedLockPath, counterFile, String(iterationsPerWorker)];
+
+        const promise = new Promise<{ index: number; exitCode: number | null; stderr: string }>((resolve) => {
+          const child = childProcess.spawn(process.execPath, args, {
+            env: { ...process.env, NODE_NO_WARNINGS: '1' },
+            stdio: ['ignore', 'ignore', 'pipe'],
+          });
+
+          let stderr = '';
+          child.stderr?.on('data', (data: Buffer) => {
+            stderr += data.toString();
+          });
+
+          child.on('close', (code) => {
+            resolve({ index: i, exitCode: code, stderr });
+          });
+
+          child.on('error', (err) => {
+            resolve({ index: i, exitCode: -1, stderr: err.message });
+          });
+        });
+
+        workerPromises.push(promise);
+      }
+
+      const results = await Promise.all(workerPromises);
+
+      // Verify all workers succeeded
+      for (const result of results) {
+        if (result.exitCode !== 0) {
+          console.error(`Parallel worker ${result.index} failed (exit ${result.exitCode}):`, result.stderr);
+        }
+        expect(result.exitCode).toBe(0);
+      }
+
+      // The final counter value must equal numWorkers * iterationsPerWorker
+      const finalCounter = parseInt(fs.readFileSync(counterFile, 'utf-8'), 10);
+      expect(finalCounter).toBe(numWorkers * iterationsPerWorker);
+    }, 60000); // 60s timeout
+  });
+});


### PR DESCRIPTION
## Summary

- Add file-based advisory locking (`src/file-lock.ts`) using `O_CREAT | O_EXCL` atomic lock files to serialize concurrent process access to the shared JSONL data file
- Prevents TOCTOU race conditions and data loss during read-merge-write cycles in `exportToJsonl()` and `refreshFromJsonlIfNewer()`
- Includes stale lock detection (PID + hostname check), configurable retry logic with timeout, and reentrancy support for nested lock acquisition

## Changes

### New files
- `src/file-lock.ts` — Core file-lock module: `acquireFileLock`, `releaseFileLock`, `withFileLock` (with reentrancy via per-path counter), `getLockPathForJsonl`, stale detection, retry logic
- `tests/file-lock.test.ts` — 38 tests: unit tests, reentrancy tests (10), concurrent multi-process integration tests (2)

### Modified files
- `src/database.ts` — Wraps `refreshFromJsonlIfNewer()` and `exportToJsonl()` with `withFileLock()`
- `src/commands/sync.ts` — Wraps `performSync()` with `withFileLock()` at the command handler level
- `src/commands/import.ts` — Wraps import operation with `withFileLock()`
- `src/commands/export.ts` — Wraps export operation with `withFileLock()`

## Design decisions

- **Reentrancy**: The sync command wraps its entire operation with a lock, but internal calls to `db.import()`/`db.importComments()` trigger `refreshFromJsonlIfNewer()` and `exportToJsonl()` which also acquire the same lock. Per-path counter in a `Map` makes nested `withFileLock()` calls transparent pass-throughs, preventing deadlock.
- **No external dependencies**: Uses only Node.js `fs` APIs (`O_CREAT | O_EXCL` for atomic creation, `process.kill(pid, 0)` for stale detection).
- **Synchronous API**: Matches the existing codebase pattern where I/O is synchronous. Busy-wait retry is intentional.

## Testing

- All 735 tests pass (78 test files)
- TypeScript compiles cleanly (`tsc --noEmit`)
- Concurrent multi-process tests spawn 4 child processes doing 10 increments each, verifying no lost writes

Work item: WL-0MLG0DSFT09AKPTK