### PR TITLE
WL-0MLZJ5P7B16JIV0W: Corrupted Lock File Recovery

### DIFF
--- a/src/file-lock.ts
+++ b/src/file-lock.ts
@@ -201,6 +201,17 @@ export function acquireFileLock(lockPath: string, options?: FileLockOptions): vo
               continue;
             }
           }
+        } else if (fs.existsSync(lockPath)) {
+          // Lock file exists but could not be parsed (corrupted, empty,
+          // or missing required fields).  Treat as stale and remove it
+          // so acquisition can be retried.
+          try {
+            fs.unlinkSync(lockPath);
+            continue;
+          } catch {
+            // Another process may have removed it; retry
+            continue;
+          }
         }
       }
 

--- a/tests/file-lock.test.ts
+++ b/tests/file-lock.test.ts
@@ -310,13 +310,73 @@ describe('file-lock', () => {
       }).toThrow(/Failed to acquire file lock/);
     });
 
-    it('should handle corrupted lock file content gracefully', () => {
+    it('should recover from corrupted lock file with garbage content', () => {
       // Write garbage content to the lock file
       fs.writeFileSync(lockPath, 'not-json-content');
 
-      // Should fail (can't parse lock info, can't determine if stale)
+      // Should succeed: corrupted lock file is treated as stale, removed, and lock acquired
+      acquireFileLock(lockPath, { retries: 1, timeout: 5000 });
+
+      // Verify our lock is now in place
+      const content = fs.readFileSync(lockPath, 'utf-8');
+      const info: FileLockInfo = JSON.parse(content);
+      expect(info.pid).toBe(process.pid);
+
+      releaseFileLock(lockPath);
+    });
+
+    it('should recover from an empty lock file (0 bytes)', () => {
+      // Write an empty file to simulate a crash during lock creation
+      fs.writeFileSync(lockPath, '');
+
+      // Should succeed: empty lock file is treated as corrupted/stale
+      acquireFileLock(lockPath, { retries: 1, timeout: 5000 });
+
+      // Verify our lock is now in place
+      const content = fs.readFileSync(lockPath, 'utf-8');
+      const info: FileLockInfo = JSON.parse(content);
+      expect(info.pid).toBe(process.pid);
+
+      releaseFileLock(lockPath);
+    });
+
+    it('should recover from lock file with valid JSON but missing required fields', () => {
+      // Write valid JSON that lacks required pid and hostname fields
+      fs.writeFileSync(lockPath, JSON.stringify({ someOtherField: 'value' }));
+
+      // Should succeed: missing required fields means readLockInfo returns null
+      acquireFileLock(lockPath, { retries: 1, timeout: 5000 });
+
+      // Verify our lock is now in place
+      const content = fs.readFileSync(lockPath, 'utf-8');
+      const info: FileLockInfo = JSON.parse(content);
+      expect(info.pid).toBe(process.pid);
+
+      releaseFileLock(lockPath);
+    });
+
+    it('should NOT treat a valid lock file as corrupted', () => {
+      // Write a properly formatted lock file held by the current (alive) process
+      const validLockInfo: FileLockInfo = {
+        pid: process.pid,
+        hostname: os.hostname(),
+        acquiredAt: new Date().toISOString(),
+      };
+      fs.writeFileSync(lockPath, JSON.stringify(validLockInfo));
+
+      // Should fail: lock is held by a live process, not corrupted
       expect(() => {
         acquireFileLock(lockPath, { retries: 0, timeout: 100 });
+      }).toThrow(/Failed to acquire file lock/);
+    });
+
+    it('should not clean up corrupted lock files when staleLockCleanup is false', () => {
+      // Write garbage content to the lock file
+      fs.writeFileSync(lockPath, 'not-json-content');
+
+      // Should fail because staleLockCleanup is disabled
+      expect(() => {
+        acquireFileLock(lockPath, { retries: 0, timeout: 100, staleLockCleanup: false });
       }).toThrow(/Failed to acquire file lock/);
     });
   });


### PR DESCRIPTION
## Summary

- Treat corrupted, empty, or malformed lock files as stale — automatically remove and retry acquisition instead of failing permanently with "unknown holder"
- Adds an `else if` branch in `acquireFileLock()` stale cleanup logic: when `readLockInfo()` returns `null` (unparseable content) but the lock file exists on disk, unlink it and retry
- Replaces the old test expecting failure on corrupted content with 5 new TDD-driven tests covering garbage content, empty files, missing fields, valid lock negative case, and `staleLockCleanup=false` guard

## Work Item

WL-0MLZJ5P7B16JIV0W (child of WL-0MLZ0M1X81PGJLRJ)

## Files Changed

- `src/file-lock.ts` — Added corrupted lock file cleanup logic (lines 204-214)
- `tests/file-lock.test.ts` — Replaced 1 test with 5 new tests (+64 lines)

## Testing

All 766 tests across 80 test files pass, including the concurrent multi-process access tests.