### PR TITLE
WL-0MLZJ6J500NLB8FI: Improve lock error messages with holder metadata and recovery guidance

### DIFF
--- a/src/file-lock.ts
+++ b/src/file-lock.ts
@@ -107,6 +107,52 @@ function sleepSync(ms: number): void {
   }
 }
 
+/**
+ * Format a lock's `acquiredAt` timestamp into a human-readable relative
+ * age string such as "12 minutes ago" or "3 seconds ago".
+ *
+ * Exported so that the `wl unlock` command can reuse it.
+ */
+export function formatLockAge(acquiredAt: string): string {
+  const ageMs = Date.now() - new Date(acquiredAt).getTime();
+  if (ageMs <= 0) {
+    return 'just now';
+  }
+  const seconds = Math.floor(ageMs / 1000);
+  if (seconds < 60) {
+    return `${seconds} ${seconds === 1 ? 'second' : 'seconds'} ago`;
+  }
+  const minutes = Math.floor(seconds / 60);
+  if (minutes < 60) {
+    return `${minutes} ${minutes === 1 ? 'minute' : 'minutes'} ago`;
+  }
+  const hours = Math.floor(minutes / 60);
+  return `${hours} ${hours === 1 ? 'hour' : 'hours'} ago`;
+}
+
+/**
+ * Build an enriched error message for lock acquisition failure.
+ * Includes lock file path, holder metadata, computed age, and recovery guidance.
+ */
+function buildLockErrorMessage(
+  lockPath: string,
+  reason: string,
+  lockInfo: FileLockInfo | null,
+): string {
+  const lines: string[] = [`Failed to acquire file lock at ${lockPath} (${reason})`];
+
+  if (lockInfo) {
+    const age = formatLockAge(lockInfo.acquiredAt);
+    lines.push(`  Held by PID ${lockInfo.pid} on ${lockInfo.hostname} since ${lockInfo.acquiredAt} (${age})`);
+  } else {
+    lines.push('  Lock file appears corrupted (corrupted lock file)');
+  }
+
+  lines.push("  Run 'wl unlock' to remove the stale lock.");
+
+  return lines.join('\n');
+}
+
 // ---------------------------------------------------------------------------
 // Reentrancy tracking
 // ---------------------------------------------------------------------------
@@ -169,11 +215,8 @@ export function acquireFileLock(lockPath: string, options?: FileLockOptions): vo
     // Check timeout
     if (Date.now() > deadline) {
       const existingInfo = readLockInfo(lockPath);
-      const holder = existingInfo
-        ? `held by PID ${existingInfo.pid} on ${existingInfo.hostname} since ${existingInfo.acquiredAt}`
-        : 'unknown holder';
       throw new Error(
-        `Failed to acquire file lock at ${lockPath} after ${timeout}ms timeout (${holder})`
+        buildLockErrorMessage(lockPath, `${timeout}ms timeout`, existingInfo)
       );
     }
 
@@ -248,11 +291,8 @@ export function acquireFileLock(lockPath: string, options?: FileLockOptions): vo
 
   // Exhausted all retries
   const existingInfo = readLockInfo(lockPath);
-  const holder = existingInfo
-    ? `held by PID ${existingInfo.pid} on ${existingInfo.hostname} since ${existingInfo.acquiredAt}`
-    : 'unknown holder';
   throw new Error(
-    `Failed to acquire file lock at ${lockPath} after ${retries} retries (${holder})`
+    buildLockErrorMessage(lockPath, `${retries} retries exhausted`, existingInfo)
   );
 }
 

--- a/tests/file-lock.test.ts
+++ b/tests/file-lock.test.ts
@@ -7,7 +7,7 @@ import * as fs from 'fs';
 import * as path from 'path';
 import * as os from 'os';
 import * as childProcess from 'child_process';
-import { acquireFileLock, releaseFileLock, withFileLock, getLockPathForJsonl, isFileLockHeld, _resetLockState } from '../src/file-lock.js';
+import { acquireFileLock, releaseFileLock, withFileLock, getLockPathForJsonl, isFileLockHeld, _resetLockState, formatLockAge } from '../src/file-lock.js';
 import type { FileLockInfo } from '../src/file-lock.js';
 import { createTempDir, cleanupTempDir } from './test-utils.js';
 
@@ -507,6 +507,130 @@ describe('file-lock', () => {
       expect(() => {
         acquireFileLock(lockPath, { retries: 0, timeout: 100, maxLockAge: 5000 });
       }).toThrow(/Failed to acquire file lock/);
+    });
+  });
+
+  describe('error messages', () => {
+    it('should include lock file path in timeout error', () => {
+      const lockInfo: FileLockInfo = {
+        pid: process.pid,
+        hostname: os.hostname(),
+        acquiredAt: new Date().toISOString(),
+      };
+      fs.writeFileSync(lockPath, JSON.stringify(lockInfo));
+
+      try {
+        acquireFileLock(lockPath, { retries: 0, timeout: 100 });
+        expect.unreachable('should have thrown');
+      } catch (err: any) {
+        expect(err.message).toContain(lockPath);
+      }
+    });
+
+    it('should include holder PID, hostname, and acquiredAt in error', () => {
+      const lockInfo: FileLockInfo = {
+        pid: process.pid,
+        hostname: os.hostname(),
+        acquiredAt: new Date().toISOString(),
+      };
+      fs.writeFileSync(lockPath, JSON.stringify(lockInfo));
+
+      try {
+        acquireFileLock(lockPath, { retries: 0, timeout: 100 });
+        expect.unreachable('should have thrown');
+      } catch (err: any) {
+        expect(err.message).toContain(`PID ${process.pid}`);
+        expect(err.message).toContain(os.hostname());
+        expect(err.message).toContain(lockInfo.acquiredAt);
+      }
+    });
+
+    it('should include human-readable lock age in error', () => {
+      const lockInfo: FileLockInfo = {
+        pid: process.pid,
+        hostname: os.hostname(),
+        acquiredAt: new Date(Date.now() - 12 * 60 * 1000).toISOString(), // 12 minutes ago
+      };
+      fs.writeFileSync(lockPath, JSON.stringify(lockInfo));
+
+      try {
+        // Use a maxLockAge larger than 12 minutes so the lock is NOT
+        // cleaned up by age-based expiry — we want the error to fire
+        // with the holder metadata intact so we can assert on the age string.
+        acquireFileLock(lockPath, { retries: 0, timeout: 100, maxLockAge: 60 * 60 * 1000 });
+        expect.unreachable('should have thrown');
+      } catch (err: any) {
+        expect(err.message).toMatch(/12 minutes? ago/);
+      }
+    });
+
+    it('should suggest wl unlock in error message', () => {
+      const lockInfo: FileLockInfo = {
+        pid: process.pid,
+        hostname: os.hostname(),
+        acquiredAt: new Date().toISOString(),
+      };
+      fs.writeFileSync(lockPath, JSON.stringify(lockInfo));
+
+      try {
+        acquireFileLock(lockPath, { retries: 0, timeout: 100 });
+        expect.unreachable('should have thrown');
+      } catch (err: any) {
+        expect(err.message).toContain('wl unlock');
+      }
+    });
+
+    it('should say corrupted lock file when lock info is unparseable', () => {
+      // Write garbage — but with staleLockCleanup disabled so it can't auto-recover
+      fs.writeFileSync(lockPath, 'not-json-content');
+
+      try {
+        acquireFileLock(lockPath, { retries: 0, timeout: 100, staleLockCleanup: false });
+        expect.unreachable('should have thrown');
+      } catch (err: any) {
+        expect(err.message).toContain('corrupted lock file');
+      }
+    });
+
+    it('should include enriched message in retries-exhausted error', () => {
+      const lockInfo: FileLockInfo = {
+        pid: process.pid,
+        hostname: os.hostname(),
+        acquiredAt: new Date(Date.now() - 30000).toISOString(), // 30 seconds ago
+      };
+      fs.writeFileSync(lockPath, JSON.stringify(lockInfo));
+
+      try {
+        acquireFileLock(lockPath, { retries: 1, retryDelay: 10, timeout: 50000 });
+        expect.unreachable('should have thrown');
+      } catch (err: any) {
+        expect(err.message).toContain(lockPath);
+        expect(err.message).toContain(`PID ${process.pid}`);
+        expect(err.message).toContain('wl unlock');
+        expect(err.message).toMatch(/ago/);
+      }
+    });
+  });
+
+  describe('formatLockAge', () => {
+    it('should format seconds ago', () => {
+      const result = formatLockAge(new Date(Date.now() - 5000).toISOString());
+      expect(result).toMatch(/5 seconds? ago/);
+    });
+
+    it('should format minutes ago', () => {
+      const result = formatLockAge(new Date(Date.now() - 3 * 60 * 1000).toISOString());
+      expect(result).toMatch(/3 minutes? ago/);
+    });
+
+    it('should format hours ago', () => {
+      const result = formatLockAge(new Date(Date.now() - 2 * 60 * 60 * 1000).toISOString());
+      expect(result).toMatch(/2 hours? ago/);
+    });
+
+    it('should handle future timestamps gracefully', () => {
+      const result = formatLockAge(new Date(Date.now() + 60000).toISOString());
+      expect(result).toMatch(/just now|0 seconds ago|in the future/);
     });
   });
 


### PR DESCRIPTION
## Summary

- Replace generic lock error messages with enriched, multi-line messages that include lock file path, holder PID/hostname, human-readable lock age, and `wl unlock` recovery guidance
- Add `formatLockAge()` helper to convert ISO timestamps to relative age strings (e.g. "12 minutes ago")
- Add `buildLockErrorMessage()` helper that constructs the enriched error message, handling both valid and corrupted lock files
- Wire up both throw sites in `acquireFileLock()` (timeout and retries-exhausted) to use the new enriched error messages

## Test coverage

- 10 new tests: 6 for error message content (path, PID, hostname, age, recovery hint, corrupted), 4 for `formatLockAge()` (seconds, minutes, hours, future timestamps)
- All 783 existing tests pass, TypeScript compiles cleanly

## Related

- Parent: WL-0MLZ0M1X81PGJLRJ (Investigate file lock acquisition failure)
- Depends on: PR #738 (corrupted lock recovery), PR #739 (age-based lock expiry)