### PR TITLE
Fix: wl list --stage excludes completed items in human-readable mode

### DIFF
--- a/src/commands/list.ts
+++ b/src/commands/list.ts
@@ -73,7 +73,10 @@ export default function register(ctx: PluginContext): void {
       // By default hide completed items for human-readable output only.
       // When JSON mode is requested return all matching items so callers
       // can decide how to handle completed items programmatically.
-      if (!options.status && !utils.isJsonMode()) {
+      // When an explicit --stage filter is provided, skip this exclusion so
+      // that stages commonly associated with completed status (e.g.
+      // "in_review", "done") are not silently dropped from human output.
+      if (!options.status && !options.stage && !utils.isJsonMode()) {
         items = items.filter(item => item.status !== 'completed');
       }
 

--- a/tests/cli/issue-status.test.ts
+++ b/tests/cli/issue-status.test.ts
@@ -129,6 +129,36 @@ describe('CLI Issue Status Tests', () => {
       result.workItems.forEach((item: any) => expect(item.needsProducerReview).not.toBe(true));
     });
 
+    it('should include completed items when --stage filter matches them', async () => {
+      // Seed items where a completed item has a specific stage
+      seedWorkItems(tempState.tempDir, [
+        { title: 'Open Task', status: 'open', priority: 'high', stage: 'in_progress' },
+        { title: 'Completed Review Task', status: 'completed', priority: 'medium', stage: 'in_review' },
+        { title: 'Another Completed', status: 'completed', priority: 'low', stage: 'done' },
+      ]);
+
+      // JSON mode should return the completed item at stage in_review
+      const { stdout: jsonStdout } = await execAsync(`tsx ${cliPath} --json list --stage in_review`);
+      const jsonResult = JSON.parse(jsonStdout);
+      expect(jsonResult.success).toBe(true);
+      expect(jsonResult.workItems).toHaveLength(1);
+      expect(jsonResult.workItems[0].title).toBe('Completed Review Task');
+
+      // Human-readable mode should also return the same item (bug: previously excluded completed items)
+      const { stdout: humanStdout } = await execAsync(`tsx ${cliPath} list --stage in_review`);
+      expect(humanStdout).toContain('Completed Review Task');
+      expect(humanStdout).toContain('Found 1 work item');
+    });
+
+    it('should still hide completed items in human mode when no stage filter is set', async () => {
+      // The default behavior (no --stage, no --status) should still hide completed items in human mode
+      const { stdout: humanStdout } = await execAsync(`tsx ${cliPath} list`);
+      // Task 3 is completed and should be hidden
+      expect(humanStdout).not.toContain('Task 3');
+      expect(humanStdout).toContain('Task 1');
+      expect(humanStdout).toContain('Task 2');
+    });
+
     it('should error for invalid parent id', async () => {
       try {
         await execAsync(`tsx ${cliPath} --json list --parent TEST-NOTFOUND`);


### PR DESCRIPTION
## Summary

Fixes a bug where `wl list --stage in_review` (human-readable mode) returned no results while `wl list --stage in_review --json` correctly returned matching items.

**Work Item:** WL-0MM0DBM6I1PHQBFI

## Root Cause

In `src/commands/list.ts:76`, the completed-item exclusion filter was applied unconditionally in human-readable mode whenever `--status` was not explicitly provided:

```typescript
if (!options.status && !utils.isJsonMode()) {
  items = items.filter(item => item.status !== 'completed');
}
```

Stages like `in_review` and `done` are commonly associated with `completed` status (per `statusStageCompatibility` config). When a user ran `wl list --stage in_review` without `--json`, all completed items were silently dropped, resulting in empty output.

## Fix

Added `!options.stage` to the condition so the completed-item exclusion is skipped when an explicit `--stage` filter is provided:

```typescript
if (!options.status && !options.stage && !utils.isJsonMode()) {
  items = items.filter(item => item.status !== 'completed');
}
```

Default behavior (no `--stage`, no `--status`) remains unchanged: completed items are still hidden in human-readable output.

## Testing

- Added test: `should include completed items when --stage filter matches them` - verifies parity between JSON and human-readable output for `--stage in_review`
- Added test: `should still hide completed items in human mode when no stage filter is set` - ensures default behavior is preserved
- All 847 tests pass

## Review Focus

- The one-line condition change in `src/commands/list.ts:76` 
- Whether other explicit filters (e.g. `--tags`, `--assignee`) should also bypass the completed-item exclusion (currently they do not)