### PR TITLE
Add dependency edge guidance to AGENTS.md docs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -79,9 +79,15 @@ Use parent/child relationships to track blocking dependencies.
 - If a work item blocks multiple items, create the parent/child relationships with the highest priority item as the parent unless one of the items is in-progress, in which case that item should be the parent.
   - If in doubt raise for product manager review.
 
-Other types of dependencies can be tracked in descriptions, for example `discovered-from:<work-item-id>`, `related-to:<work-item-id>`, `blocked-by:<work-item-id>`.
+For non-hierarchical blocking relationships, prefer dependency edges over description-based conventions. Dependency edges are the recommended way to track blockers:
 
-Worklog does not enforce these relationships but they can be used for planning and tracking.
+```bash
+wl dep add <dependent-work-item-id> <prereq-work-item-id>
+wl dep list <work-item-id> --json
+wl dep rm <dependent-work-item-id> <prereq-work-item-id>
+```
+
+Description-based conventions (`discovered-from:<work-item-id>`, `related-to:<work-item-id>`, `blocked-by:<work-item-id>`) remain supported for informal cross-references and planning notes, but dependency edges should be used for any relationship that affects scheduling or blocking.
 
 ### Workflow management
 
@@ -133,6 +139,12 @@ wl close <work-item-id-1> <work-item-id-2> --json
 
 # *Destructive command ask for confirmation before running* Dekete a work item permanently
 wl delete <work-item-id> --json
+
+# Dependencies
+wl dep --help  # Show help for dependency commands
+wl dep add <dependent-work-item-id> <prereq-work-item-id>
+wl dep list <work-item-id> --json
+wl dep rm <dependent-work-item-id> <prereq-work-item-id>
 ```
 
 ### Project Status

--- a/templates/AGENTS.md
+++ b/templates/AGENTS.md
@@ -77,9 +77,15 @@ Use parent/child relationships to track blocking dependencies.
 - If a work item blocks multiple items, create the parent/child relationships with the highest priority item as the parent unless one of the items is in-progress, in which case that item should be the parent.
   - If in doubt raise for product manager review.
 
-Other types of dependencies can be tracked in descriptions, for example `discovered-from:<work-item-id>`, `related-to:<work-item-id>`, `blocked-by:<work-item-id>`.
+For non-hierarchical blocking relationships, prefer dependency edges over description-based conventions. Dependency edges are the recommended way to track blockers:
 
-Worklog does not enforce these relationships but they can be used for planning and tracking.
+```bash
+wl dep add <dependent-work-item-id> <prereq-work-item-id>
+wl dep list <work-item-id> --json
+wl dep rm <dependent-work-item-id> <prereq-work-item-id>
+```
+
+Description-based conventions (`discovered-from:<work-item-id>`, `related-to:<work-item-id>`, `blocked-by:<work-item-id>`) remain supported for informal cross-references and planning notes, but dependency edges should be used for any relationship that affects scheduling or blocking.
 
 ### Workflow management
 
@@ -131,6 +137,12 @@ wl close <work-item-id-1> <work-item-id-2> --json
 
 # *Destructive command ask for confirmation before running* Dekete a work item permanently
 wl delete <work-item-id> --json
+
+# Dependencies
+wl dep --help  # Show help for dependency commands
+wl dep add <dependent-work-item-id> <prereq-work-item-id>
+wl dep list <work-item-id> --json
+wl dep rm <dependent-work-item-id> <prereq-work-item-id>
 ```
 
 ### Project Status


### PR DESCRIPTION
## Summary

Updates AGENTS.md and templates/AGENTS.md to document `wl dep` commands as the recommended way to track blocking dependencies, closing a documentation gap where these files only mentioned description-based conventions (`blocked-by:<id>`).

## Changes

- **Dependencies section** (both files): Added guidance recommending dependency edges (`wl dep add/rm/list`) as the preferred approach for non-hierarchical blocking relationships. Description-based conventions (`discovered-from`, `related-to`, `blocked-by`) are noted as still supported for informal cross-references.
- **Work-Item Management section** (both files): Added `wl dep` command examples (`add`, `list`, `rm`) to the bash command reference block.

## Context

- CLI.md already correctly documents the `wl dep` subcommands and recommends dependency edges (line 156), but AGENTS.md files had no mention of `wl dep` at all.
- This aligns the agent onboarding docs with the CLI reference and the operator's global AGENTS.md which already included this guidance.

## Testing

- All validator tests pass (`tests/validator.test.ts`, `test/validator.test.ts`)
- 8 pre-existing flaky test timeouts are unrelated to these documentation-only changes

## Review Focus

- Verify the wording in the Dependencies sections accurately conveys that dependency edges are preferred but description-based conventions remain supported
- Confirm the `wl dep` command examples match the actual CLI interface

Work item: WL-0ML4TFY0S0IHS06O (Docs checks for dependency edge guidance)
Parent: WL-0ML4TFTCJ0PGY47E (Document dependency edges)