### PR TITLE
WL-0MM34576E1WOBCZ8: Regression Test Suite for Prior Bug Fixes

### DIFF
--- a/tests/next-regression.test.ts
+++ b/tests/next-regression.test.ts
@@ -1,0 +1,723 @@
+/**
+ * Regression test suite for the `wl next` selection algorithm.
+ *
+ * Each test case locks in a prior bug-fix scenario so that the algorithm
+ * rebuild (WL-0MM2FKKOW1H0C0G4) does not regress previously fixed behaviors.
+ *
+ * Tests call the public `db.findNextWorkItem()` / `db.findNextWorkItems()`
+ * entry points against a fresh in-memory database populated inline.
+ *
+ * Pattern notes:
+ *   - Uses `await wait(10)` between creates when tests depend on distinct
+ *     `createdAt` timestamps (per WL-0MM17NRAY0FJ1AK5 flaky-test fix).
+ *   - Uses `createTempDir` / `cleanupTempDir` helpers for temp DB isolation.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import * as fs from 'fs';
+import * as path from 'path';
+import { WorklogDatabase } from '../src/database.js';
+import {
+  createTempDir,
+  cleanupTempDir,
+  createTempJsonlPath,
+  createTempDbPath,
+  wait,
+} from './test-utils.js';
+
+describe('wl next regression tests (WL-0MM2FKKOW1H0C0G4)', () => {
+  let tempDir: string;
+  let dbPath: string;
+  let jsonlPath: string;
+  let db: WorklogDatabase;
+
+  beforeEach(() => {
+    tempDir = createTempDir();
+    dbPath = createTempDbPath(tempDir);
+    jsonlPath = createTempJsonlPath(tempDir);
+    db = new WorklogDatabase('TEST', dbPath, jsonlPath, true, true);
+  });
+
+  afterEach(() => {
+    db.close();
+    cleanupTempDir(tempDir);
+  });
+
+  // ─────────────────────────────────────────────────────────────────────
+  // Regression: Deleted items filtered (WL-0MLDIFLCR1REKNGA)
+  // Deleted items must never be returned by wl next.
+  // ─────────────────────────────────────────────────────────────────────
+  describe('deleted items filtered (WL-0MLDIFLCR1REKNGA)', () => {
+    it('should never return a deleted item even if it has the highest priority', () => {
+      db.create({ title: 'Deleted critical', priority: 'critical', status: 'deleted' });
+      const openItem = db.create({ title: 'Open low', priority: 'low', status: 'open' });
+
+      const result = db.findNextWorkItem();
+      expect(result.workItem).not.toBeNull();
+      expect(result.workItem!.id).toBe(openItem.id);
+    });
+
+    it('should return null when only deleted items exist', () => {
+      db.create({ title: 'Deleted A', priority: 'high', status: 'deleted' });
+      db.create({ title: 'Deleted B', priority: 'critical', status: 'deleted' });
+
+      const result = db.findNextWorkItem();
+      expect(result.workItem).toBeNull();
+    });
+
+    it('should filter deleted items from batch results', () => {
+      db.create({ title: 'Deleted', priority: 'critical', status: 'deleted' });
+      const a = db.create({ title: 'Open A', priority: 'high', status: 'open' });
+      const b = db.create({ title: 'Open B', priority: 'medium', status: 'open' });
+
+      const results = db.findNextWorkItems(3);
+      const ids = results.map(r => r.workItem?.id).filter(Boolean);
+      expect(ids).not.toContain(undefined);
+      // Should contain only non-deleted items
+      for (const r of results) {
+        if (r.workItem) {
+          expect(r.workItem.status).not.toBe('deleted');
+        }
+      }
+    });
+  });
+
+  // ─────────────────────────────────────────────────────────────────────
+  // Regression: Orphan promotion under completed/deleted parents
+  //             (WL-0MM1CD2IJ1R2ZI5J)
+  // Items whose ancestors are completed or deleted must be promoted to
+  // root level and compete on their own sortIndex.
+  // ─────────────────────────────────────────────────────────────────────
+  describe('orphan promotion under completed/deleted parents (WL-0MM1CD2IJ1R2ZI5J)', () => {
+    it('should promote open child under completed parent to root level', () => {
+      const completedParent = db.create({
+        title: 'Completed parent',
+        priority: 'high',
+        status: 'completed',
+        sortIndex: 100,
+      });
+      const orphan = db.create({
+        title: 'Orphan task',
+        priority: 'low',
+        status: 'open',
+        parentId: completedParent.id,
+        sortIndex: 300,
+      });
+      const rootItem = db.create({
+        title: 'Root feature',
+        priority: 'medium',
+        status: 'open',
+        sortIndex: 50,
+      });
+
+      const result = db.findNextWorkItem();
+      expect(result.workItem).not.toBeNull();
+      // rootItem (sortIndex=50) should sort before orphan (sortIndex=300)
+      // since orphan is now at root level, not hidden under parent at 100
+      expect(result.workItem!.id).toBe(rootItem.id);
+    });
+
+    it('should promote deeply nested orphan when all ancestors are completed', () => {
+      const root = db.create({ title: 'Root', priority: 'high', status: 'completed', sortIndex: 100 });
+      const l1 = db.create({ title: 'L1', priority: 'high', status: 'completed', parentId: root.id, sortIndex: 200 });
+      const l2 = db.create({ title: 'L2', priority: 'high', status: 'completed', parentId: l1.id, sortIndex: 300 });
+      const orphan = db.create({ title: 'Deep orphan', priority: 'medium', status: 'open', parentId: l2.id, sortIndex: 400 });
+      const anotherRoot = db.create({ title: 'Another root', priority: 'medium', status: 'open', sortIndex: 50 });
+
+      const result = db.findNextWorkItem();
+      expect(result.workItem).not.toBeNull();
+      // anotherRoot (sortIndex=50) should be picked first
+      expect(result.workItem!.id).toBe(anotherRoot.id);
+    });
+
+    it('should promote orphan under deleted parent to root level', () => {
+      const deletedParent = db.create({ title: 'Deleted parent', priority: 'high', status: 'deleted', sortIndex: 100 });
+      const orphan = db.create({ title: 'Orphan under deleted', priority: 'medium', status: 'open', parentId: deletedParent.id, sortIndex: 200 });
+      const rootItem = db.create({ title: 'Root item', priority: 'medium', status: 'open', sortIndex: 50 });
+
+      const result = db.findNextWorkItem();
+      expect(result.workItem).not.toBeNull();
+      expect(result.workItem!.id).toBe(rootItem.id);
+    });
+
+    it('should NOT promote child when parent is open', () => {
+      const parent = db.create({ title: 'Open parent', priority: 'medium', status: 'open', sortIndex: 100 });
+      const child = db.create({ title: 'Child task', priority: 'medium', status: 'open', parentId: parent.id, sortIndex: 200 });
+
+      const result = db.findNextWorkItem();
+      expect(result.workItem).not.toBeNull();
+      // Parent is open, so child stays under parent in hierarchy and child
+      // is returned via hierarchy descent
+      expect(result.workItem!.id).toBe(child.id);
+    });
+  });
+
+  // ─────────────────────────────────────────────────────────────────────
+  // Regression: Childless epic eligibility (WL-0MM1CD3SP1CO6NK9)
+  // Epics without children must not be excluded from the candidate list.
+  // ─────────────────────────────────────────────────────────────────────
+  describe('childless epic eligibility (WL-0MM1CD3SP1CO6NK9)', () => {
+    it('should surface a childless epic as a candidate', () => {
+      const epic = db.create({
+        title: 'Important epic',
+        priority: 'high',
+        status: 'open',
+        issueType: 'epic',
+        sortIndex: 100,
+      });
+
+      const result = db.findNextWorkItem();
+      expect(result.workItem).not.toBeNull();
+      expect(result.workItem!.id).toBe(epic.id);
+    });
+
+    it('should surface a critical childless epic over lower-priority non-epics', () => {
+      db.create({ title: 'Low task', priority: 'low', status: 'open', sortIndex: 50 });
+      const criticalEpic = db.create({
+        title: 'Critical epic',
+        priority: 'critical',
+        status: 'open',
+        issueType: 'epic',
+        sortIndex: 200,
+      });
+
+      const result = db.findNextWorkItem();
+      expect(result.workItem).not.toBeNull();
+      expect(result.workItem!.id).toBe(criticalEpic.id);
+    });
+
+    it('should descend into epic children when they exist', () => {
+      const epic = db.create({ title: 'Parent epic', priority: 'high', status: 'open', issueType: 'epic', sortIndex: 100 });
+      const child = db.create({ title: 'Child task', priority: 'medium', status: 'open', parentId: epic.id, sortIndex: 200 });
+
+      const result = db.findNextWorkItem();
+      expect(result.workItem).not.toBeNull();
+      expect(result.workItem!.id).toBe(child.id);
+    });
+
+    it('should return the epic itself when all children are completed', () => {
+      const epic = db.create({ title: 'Nearly done epic', priority: 'high', status: 'open', issueType: 'epic', sortIndex: 100 });
+      db.create({ title: 'Done child', priority: 'medium', status: 'completed', parentId: epic.id, sortIndex: 200 });
+
+      const result = db.findNextWorkItem();
+      expect(result.workItem).not.toBeNull();
+      expect(result.workItem!.id).toBe(epic.id);
+    });
+  });
+
+  // ─────────────────────────────────────────────────────────────────────
+  // Regression: Batch dedup / unique results (WL-0MLFU4PQA1EJ1OQK)
+  // `findNextWorkItems(n)` must return unique items, no duplicates.
+  // ─────────────────────────────────────────────────────────────────────
+  describe('batch dedup / unique results (WL-0MLFU4PQA1EJ1OQK)', () => {
+    it('should return unique items in batch mode', () => {
+      const a = db.create({ title: 'Task A', priority: 'high', status: 'open' });
+      const b = db.create({ title: 'Task B', priority: 'medium', status: 'open' });
+      const c = db.create({ title: 'Task C', priority: 'low', status: 'open' });
+
+      const results = db.findNextWorkItems(3);
+      const ids = results.map(r => r.workItem?.id).filter(Boolean);
+      // All IDs must be unique
+      expect(new Set(ids).size).toBe(ids.length);
+      expect(ids.length).toBe(3);
+    });
+
+    it('should not return duplicates when requesting more items than available', () => {
+      db.create({ title: 'Task A', priority: 'high', status: 'open' });
+      db.create({ title: 'Task B', priority: 'medium', status: 'open' });
+
+      const results = db.findNextWorkItems(5);
+      const ids = results.map(r => r.workItem?.id).filter(Boolean);
+      // Should only return 2 items (no padding with duplicates or nulls)
+      expect(new Set(ids).size).toBe(ids.length);
+      expect(ids.length).toBeLessThanOrEqual(2);
+    });
+
+    it('should return unique items with hierarchy', () => {
+      const parent = db.create({ title: 'Parent', priority: 'high', status: 'open', sortIndex: 100 });
+      const child1 = db.create({ title: 'Child 1', priority: 'high', status: 'open', parentId: parent.id, sortIndex: 200 });
+      const child2 = db.create({ title: 'Child 2', priority: 'medium', status: 'open', parentId: parent.id, sortIndex: 300 });
+      const other = db.create({ title: 'Other root', priority: 'medium', status: 'open', sortIndex: 400 });
+
+      const results = db.findNextWorkItems(3);
+      const ids = results.map(r => r.workItem?.id).filter(Boolean);
+      expect(new Set(ids).size).toBe(ids.length);
+    });
+  });
+
+  // ─────────────────────────────────────────────────────────────────────
+  // Regression: In-review exclusion (WL-0ML2TS8I409ALBU6)
+  // Items with status=blocked + stage=in_review must be excluded by
+  // default, but included when --include-in-review is set.
+  // ─────────────────────────────────────────────────────────────────────
+  describe('in-review exclusion (WL-0ML2TS8I409ALBU6)', () => {
+    it('should exclude blocked in_review items by default', () => {
+      const inReview = db.create({
+        title: 'In review',
+        status: 'blocked',
+        stage: 'in_review',
+        priority: 'high',
+      });
+      const openItem = db.create({ title: 'Open', status: 'open', priority: 'low' });
+
+      const result = db.findNextWorkItem();
+      expect(result.workItem).not.toBeNull();
+      expect(result.workItem!.id).toBe(openItem.id);
+      expect(result.workItem!.id).not.toBe(inReview.id);
+    });
+
+    it('should include blocked in_review items when includeInReview=true', () => {
+      const inReview = db.create({
+        title: 'In review',
+        status: 'blocked',
+        stage: 'in_review',
+        priority: 'high',
+      });
+      db.create({ title: 'Open', status: 'open', priority: 'low' });
+
+      const result = db.findNextWorkItem(undefined, undefined, 'ignore', true);
+      expect(result.workItem).not.toBeNull();
+      expect(result.workItem!.id).toBe(inReview.id);
+    });
+
+    it('should return null when only in-review items exist and flag is off', () => {
+      db.create({ title: 'In review only', status: 'blocked', stage: 'in_review', priority: 'critical' });
+
+      const result = db.findNextWorkItem();
+      expect(result.workItem).toBeNull();
+    });
+  });
+
+  // ─────────────────────────────────────────────────────────────────────
+  // Regression: Blocker-vs-priority ordering (WL-0MLYHCZCS1FY5I6H)
+  // A higher-priority open item must win over the blocker of a
+  // lower-priority blocked item.
+  // ─────────────────────────────────────────────────────────────────────
+  describe('blocker-vs-priority ordering (WL-0MLYHCZCS1FY5I6H)', () => {
+    it('should prefer higher-priority open item over blocker of lower-priority blocked item', () => {
+      // A (medium, open) blocks B (medium, blocked)
+      // C (high, open) -- should win
+      const blockerA = db.create({ title: 'Blocker A', priority: 'medium', status: 'open' });
+      const blockedB = db.create({ title: 'Blocked B', priority: 'medium', status: 'blocked' });
+      db.addDependencyEdge(blockedB.id, blockerA.id);
+      const highC = db.create({ title: 'High priority C', priority: 'high', status: 'open' });
+
+      const result = db.findNextWorkItem();
+      expect(result.workItem!.id).toBe(highC.id);
+    });
+
+    it('should prefer blocker when blocked item has higher priority than all competitors', () => {
+      // X (medium, open) blocks Y (critical, blocked)
+      // Z (high, open) -- should lose because Y is critical
+      const blockerX = db.create({ title: 'Blocker X', priority: 'medium', status: 'open' });
+      const blockedY = db.create({ title: 'Blocked Y', priority: 'critical', status: 'blocked' });
+      db.addDependencyEdge(blockedY.id, blockerX.id);
+      db.create({ title: 'High priority Z', priority: 'high', status: 'open' });
+
+      const result = db.findNextWorkItem();
+      expect(result.workItem!.id).toBe(blockerX.id);
+    });
+
+    it('should prefer blocker when blocked item has equal priority to best competitor', () => {
+      // Blocker (low) blocks BlockedItem (high, blocked)
+      // Competitor (high, open)
+      // Blocked item priority (high) is >= competitor (high), so blocker wins
+      const blocker = db.create({ title: 'Blocker', priority: 'low', status: 'open' });
+      const blockedItem = db.create({ title: 'Blocked item', priority: 'high', status: 'blocked' });
+      db.addDependencyEdge(blockedItem.id, blocker.id);
+      db.create({ title: 'Competitor', priority: 'high', status: 'open' });
+
+      const result = db.findNextWorkItem();
+      expect(result.workItem!.id).toBe(blocker.id);
+    });
+
+    it('should prefer higher-priority open item over child blocker of lower-priority blocked item', () => {
+      const parent = db.create({ title: 'Blocked parent', priority: 'medium', status: 'blocked' });
+      db.create({ title: 'Blocking child', priority: 'low', status: 'open', parentId: parent.id });
+      const highItem = db.create({ title: 'High priority item', priority: 'high', status: 'open' });
+
+      const result = db.findNextWorkItem();
+      expect(result.workItem!.id).toBe(highItem.id);
+    });
+
+    it('should prefer child blocker when blocked parent has critical priority', () => {
+      const parent = db.create({ title: 'Blocked parent', priority: 'critical', status: 'blocked' });
+      const childBlocker = db.create({ title: 'Blocking child', priority: 'low', status: 'open', parentId: parent.id });
+      db.create({ title: 'High priority item', priority: 'high', status: 'open' });
+
+      const result = db.findNextWorkItem();
+      expect(result.workItem!.id).toBe(childBlocker.id);
+    });
+  });
+
+  // ─────────────────────────────────────────────────────────────────────
+  // Regression: Blocked item filtering (WL-0MLZWO96O1RS086V)
+  // Dependency-blocked items must be excluded by default and included
+  // when --include-blocked is set.
+  // ─────────────────────────────────────────────────────────────────────
+  describe('blocked item filtering (WL-0MLZWO96O1RS086V)', () => {
+    it('should not return a dependency-blocked item by default', () => {
+      const itemA = db.create({ title: 'Dep-blocked A', priority: 'high', status: 'open' });
+      const itemB = db.create({ title: 'Prerequisite B', priority: 'low', status: 'open' });
+      db.addDependencyEdge(itemA.id, itemB.id);
+      const itemC = db.create({ title: 'Unblocked C', priority: 'medium', status: 'open' });
+
+      const result = db.findNextWorkItem();
+      expect(result.workItem!.id).not.toBe(itemA.id);
+      expect([itemB.id, itemC.id]).toContain(result.workItem!.id);
+    });
+
+    it('should return a dependency-blocked item when includeBlocked=true', () => {
+      const itemA = db.create({ title: 'Dep-blocked A', priority: 'high', status: 'open' });
+      const itemB = db.create({ title: 'Prerequisite B', priority: 'low', status: 'open' });
+      db.addDependencyEdge(itemA.id, itemB.id);
+
+      const result = db.findNextWorkItem(undefined, undefined, 'ignore', false, true);
+      expect(result.workItem).not.toBeNull();
+      // With includeBlocked, A should be in the candidate pool
+    });
+
+    it('should not filter items whose dependency target is completed (edge inactive)', () => {
+      const itemA = db.create({ title: 'Formerly blocked A', priority: 'high', status: 'open' });
+      const itemB = db.create({ title: 'Completed prerequisite B', priority: 'low', status: 'completed' });
+      db.addDependencyEdge(itemA.id, itemB.id);
+
+      const result = db.findNextWorkItem();
+      expect(result.workItem!.id).toBe(itemA.id);
+    });
+
+    it('should still surface blockers for critical dep-blocked items', () => {
+      const itemY = db.create({ title: 'Blocker Y', priority: 'low', status: 'open' });
+      const itemX = db.create({ title: 'Critical blocked X', priority: 'critical', status: 'blocked' });
+      db.addDependencyEdge(itemX.id, itemY.id);
+
+      const result = db.findNextWorkItem();
+      expect(result.workItem!.id).toBe(itemY.id);
+    });
+
+    it('should not return a dep-blocked in-progress item', () => {
+      const inProgressItem = db.create({ title: 'In-progress dep-blocked', priority: 'high', status: 'in-progress' });
+      const prereq = db.create({ title: 'Prerequisite', priority: 'low', status: 'open' });
+      db.addDependencyEdge(inProgressItem.id, prereq.id);
+      const openItem = db.create({ title: 'Available open item', priority: 'medium', status: 'open' });
+
+      const result = db.findNextWorkItem();
+      expect(result.workItem!.id).not.toBe(inProgressItem.id);
+      expect([prereq.id, openItem.id]).toContain(result.workItem!.id);
+    });
+  });
+
+  // ─────────────────────────────────────────────────────────────────────
+  // Regression: Priority inheritance / scoring boost (WL-0MM0B4FNW0ZLOTV8)
+  // Items that block high/critical-priority items must be prioritized
+  // above equal-priority peers that block nothing.
+  // ─────────────────────────────────────────────────────────────────────
+  describe('priority inheritance / scoring boost (WL-0MM0B4FNW0ZLOTV8)', () => {
+    it('should prefer item blocking a critical downstream item over equal-priority peer', () => {
+      const itemA = db.create({ title: 'Unblocker A', priority: 'high', status: 'open' });
+      db.create({ title: 'Plain B', priority: 'high', status: 'open' });
+      const criticalDownstream = db.create({ title: 'Critical downstream', priority: 'critical', status: 'blocked' });
+      db.addDependencyEdge(criticalDownstream.id, itemA.id);
+
+      const result = db.findNextWorkItem();
+      expect(result.workItem!.id).toBe(itemA.id);
+    });
+
+    it('should prefer item blocking a high downstream item over equal-priority peer', () => {
+      const itemA = db.create({ title: 'Unblocker A', priority: 'medium', status: 'open' });
+      db.create({ title: 'Plain B', priority: 'medium', status: 'open' });
+      const highDownstream = db.create({ title: 'High downstream', priority: 'high', status: 'blocked' });
+      db.addDependencyEdge(highDownstream.id, itemA.id);
+
+      const result = db.findNextWorkItem();
+      expect(result.workItem!.id).toBe(itemA.id);
+    });
+
+    it('should preserve priority dominance: high beats medium that blocks high', () => {
+      // A is high priority, blocks nothing
+      // B is medium priority, blocks a high-priority downstream
+      // A should still win because own priority > boost
+      const itemA = db.create({ title: 'High priority A', priority: 'high', status: 'open' });
+      const itemB = db.create({ title: 'Medium unblocker B', priority: 'medium', status: 'open' });
+      const highDownstream = db.create({ title: 'High downstream', priority: 'high', status: 'open' });
+      db.addDependencyEdge(highDownstream.id, itemB.id);
+
+      const result = db.findNextWorkItem();
+      expect(result.workItem!.id).toBe(itemA.id);
+    });
+
+    it('should prefer item blocking critical over item blocking only high', () => {
+      const itemA = db.create({ title: 'Unblocker A', priority: 'medium', status: 'open' });
+      const itemB = db.create({ title: 'Unblocker B', priority: 'medium', status: 'open' });
+      const criticalDownstream = db.create({ title: 'Critical downstream', priority: 'critical', status: 'blocked' });
+      const highDownstream = db.create({ title: 'High downstream', priority: 'high', status: 'blocked' });
+      db.addDependencyEdge(criticalDownstream.id, itemA.id);
+      db.addDependencyEdge(highDownstream.id, itemB.id);
+
+      const result = db.findNextWorkItem();
+      expect(result.workItem!.id).toBe(itemA.id);
+    });
+
+    it('should NOT boost an item that only blocks low/medium priority items', async () => {
+      const itemA = db.create({ title: 'Blocks low A', priority: 'medium', status: 'open' });
+      const lowDownstream = db.create({ title: 'Low downstream', priority: 'low', status: 'open' });
+      db.addDependencyEdge(lowDownstream.id, itemA.id);
+      await wait(10);
+      const itemB = db.create({ title: 'Plain B', priority: 'medium', status: 'open' });
+
+      const result = db.findNextWorkItem();
+      // A should win by age (older), NOT by boost since low doesn't qualify
+      expect(result.workItem!.id).toBe(itemA.id);
+
+      // Verify reverse: if B is older, B wins (no boost on A for medium)
+      const db2TempDir = createTempDir();
+      const db2Path = createTempDbPath(db2TempDir);
+      const db2JsonlPath = createTempJsonlPath(db2TempDir);
+      const db2 = new WorklogDatabase('TEST', db2Path, db2JsonlPath, true, true);
+      try {
+        const olderB = db2.create({ title: 'Older plain B', priority: 'medium', status: 'open' });
+        await wait(10);
+        const newerA = db2.create({ title: 'Blocks medium A', priority: 'medium', status: 'open' });
+        const medDownstream = db2.create({ title: 'Medium downstream', priority: 'medium', status: 'open' });
+        db2.addDependencyEdge(medDownstream.id, newerA.id);
+
+        const result2 = db2.findNextWorkItem();
+        expect(result2.workItem!.id).toBe(olderB.id);
+      } finally {
+        db2.close();
+        cleanupTempDir(db2TempDir);
+      }
+    });
+
+    it('should not boost for completed or deleted downstream items', async () => {
+      const itemA = db.create({ title: 'Unblocker A', priority: 'medium', status: 'open' });
+      await wait(10);
+      const itemB = db.create({ title: 'Plain B', priority: 'medium', status: 'open' });
+      const completedCritical = db.create({ title: 'Completed critical', priority: 'critical', status: 'completed' });
+      db.addDependencyEdge(completedCritical.id, itemA.id);
+
+      const result = db.findNextWorkItem();
+      // A should NOT get a boost; wins by age (older)
+      expect(result.workItem!.id).toBe(itemA.id);
+
+      // Verify with deleted status
+      const db2TempDir = createTempDir();
+      const db2Path = createTempDbPath(db2TempDir);
+      const db2JsonlPath = createTempJsonlPath(db2TempDir);
+      const db2 = new WorklogDatabase('TEST', db2Path, db2JsonlPath, true, true);
+      try {
+        const olderB2 = db2.create({ title: 'Older B', priority: 'medium', status: 'open' });
+        await wait(10);
+        const newerA2 = db2.create({ title: 'Blocks deleted A', priority: 'medium', status: 'open' });
+        const deletedCritical = db2.create({ title: 'Deleted critical', priority: 'critical', status: 'deleted' });
+        db2.addDependencyEdge(deletedCritical.id, newerA2.id);
+
+        const result2 = db2.findNextWorkItem();
+        // No boost for deleted items; B is older so B wins
+        expect(result2.workItem!.id).toBe(olderB2.id);
+      } finally {
+        db2.close();
+        cleanupTempDir(db2TempDir);
+      }
+    });
+  });
+
+  // ─────────────────────────────────────────────────────────────────────
+  // Regression: Flaky test timing pattern (WL-0MM17NRAY0FJ1AK5)
+  // Tests that depend on distinct createdAt timestamps must use
+  // async+delay to avoid flaky results.
+  // ─────────────────────────────────────────────────────────────────────
+  describe('age-based tiebreaker with timing (WL-0MM17NRAY0FJ1AK5)', () => {
+    it('should select oldest item when priorities are equal', async () => {
+      const oldest = db.create({ title: 'Oldest', priority: 'high', status: 'open' });
+      await wait(10);
+      db.create({ title: 'Newer', priority: 'high', status: 'open' });
+
+      const result = db.findNextWorkItem();
+      expect(result.workItem!.id).toBe(oldest.id);
+    });
+
+    it('should select oldest item in batch mode as first result', async () => {
+      const oldest = db.create({ title: 'Oldest', priority: 'medium', status: 'open' });
+      await wait(10);
+      const newer = db.create({ title: 'Newer', priority: 'medium', status: 'open' });
+
+      const results = db.findNextWorkItems(2);
+      expect(results[0].workItem!.id).toBe(oldest.id);
+      expect(results[1].workItem!.id).toBe(newer.id);
+    });
+  });
+
+  // ─────────────────────────────────────────────────────────────────────
+  // Regression: Blocked/in-review flag behavior (WL-0MLC3SUXI0QI9I3L)
+  // The --include-in-review flag must correctly control inclusion of
+  // blocked items with stage=in_review.
+  // ─────────────────────────────────────────────────────────────────────
+  describe('blocked/in-review flag behavior (WL-0MLC3SUXI0QI9I3L)', () => {
+    it('should exclude blocked+in_review by default', () => {
+      db.create({ title: 'In review', status: 'blocked', stage: 'in_review', priority: 'critical' });
+      const openItem = db.create({ title: 'Open', status: 'open', priority: 'low' });
+
+      const result = db.findNextWorkItem();
+      expect(result.workItem!.id).toBe(openItem.id);
+    });
+
+    it('should include blocked+in_review when includeInReview=true', () => {
+      const inReview = db.create({ title: 'In review', status: 'blocked', stage: 'in_review', priority: 'critical' });
+      db.create({ title: 'Open', status: 'open', priority: 'low' });
+
+      const result = db.findNextWorkItem(undefined, undefined, 'ignore', true);
+      expect(result.workItem!.id).toBe(inReview.id);
+    });
+
+    it('should not affect blocked items without in_review stage', () => {
+      // A regular blocked item (not in_review) should be handled by normal blocked logic
+      const blocked = db.create({ title: 'Blocked', status: 'blocked', priority: 'high' });
+      const blocker = db.create({ title: 'Blocker child', status: 'open', priority: 'low', parentId: blocked.id });
+
+      const result = db.findNextWorkItem();
+      // Should surface the blocker for the blocked item
+      expect(result.workItem!.id).toBe(blocker.id);
+    });
+
+    it('should not affect open items with in_review stage (edge case)', () => {
+      // An open item with stage=in_review is NOT blocked, so the filter shouldn't apply
+      const openInReview = db.create({ title: 'Open in review', status: 'open', stage: 'in_review', priority: 'high' });
+
+      const result = db.findNextWorkItem();
+      expect(result.workItem!.id).toBe(openInReview.id);
+    });
+  });
+
+  // ─────────────────────────────────────────────────────────────────────
+  // Regression: Formal-only blocking (WL-0MLPSNIEL161NV6C)
+  // Only formal relationships (children, dependency edges) should
+  // identify blockers. Description/comment text must be ignored.
+  // ─────────────────────────────────────────────────────────────────────
+  describe('formal-only blocking (WL-0MLPSNIEL161NV6C)', () => {
+    it('should ignore blocking issues mentioned in description', () => {
+      const blocker = db.create({ title: 'Blocking issue', priority: 'low', status: 'open' });
+      const blocked = db.create({
+        title: 'Blocked task',
+        priority: 'high',
+        status: 'blocked',
+        description: `This is blocked by ${blocker.id}`,
+      });
+
+      const result = db.findNextWorkItem();
+      // Should return the blocked item since description hints are ignored
+      expect(result.workItem!.id).toBe(blocked.id);
+    });
+
+    it('should ignore blocking issues mentioned in comments', () => {
+      const blocker = db.create({ title: 'Blocking issue', priority: 'medium', status: 'open' });
+      const blocked = db.create({ title: 'Blocked task', priority: 'high', status: 'blocked' });
+      db.createComment({
+        workItemId: blocked.id,
+        author: 'test',
+        comment: `Cannot proceed due to ${blocker.id}`,
+      });
+
+      const result = db.findNextWorkItem();
+      expect(result.workItem!.id).toBe(blocked.id);
+    });
+  });
+
+  // ─────────────────────────────────────────────────────────────────────
+  // Regression: Fixture-based integration (next-ranking-fixture.jsonl)
+  // Verifies the dependency-chain scoring boost using the generalized
+  // fixture file.
+  // ─────────────────────────────────────────────────────────────────────
+  describe('fixture: next-ranking dependency chain', () => {
+    let fixtureTempDir: string;
+    let fixtureDb: WorklogDatabase;
+
+    beforeEach(() => {
+      fixtureTempDir = createTempDir();
+      const fixtureSource = path.resolve(__dirname, 'fixtures', 'next-ranking-fixture.jsonl');
+      const fixtureJsonlPath = createTempJsonlPath(fixtureTempDir);
+      const fixtureDbPath = createTempDbPath(fixtureTempDir);
+      fs.copyFileSync(fixtureSource, fixtureJsonlPath);
+      fixtureDb = new WorklogDatabase('FIX', fixtureDbPath, fixtureJsonlPath, false, true);
+    });
+
+    afterEach(() => {
+      fixtureDb.close();
+      cleanupTempDir(fixtureTempDir);
+    });
+
+    it('should prefer medium-priority unblocker over equal-priority peers when it blocks a high-priority item', () => {
+      // FIX-PHASE2 (medium, open) blocks FIX-PHASE3 (high)
+      // FIX-DISTRACT-A and FIX-DISTRACT-B are medium, open, no deps
+      // FIX-PHASE2 should win due to blocking boost
+      const result = fixtureDb.findNextWorkItem();
+      expect(result.workItem).not.toBeNull();
+      expect(result.workItem!.id).toBe('FIX-PHASE2');
+    });
+
+    it('should select unblocked high-priority item over medium unblocker', () => {
+      // Adding a new high-priority unblocked item should beat FIX-PHASE2
+      const highItem = fixtureDb.create({ title: 'Urgent high item', priority: 'high', status: 'open' });
+
+      const result = fixtureDb.findNextWorkItem();
+      expect(result.workItem).not.toBeNull();
+      expect(result.workItem!.id).toBe(highItem.id);
+    });
+  });
+
+  // ─────────────────────────────────────────────────────────────────────
+  // Regression: In-progress handling
+  // wl next should not return in-progress items themselves. It should
+  // descend into children or fall back to other open items.
+  // ─────────────────────────────────────────────────────────────────────
+  describe('in-progress handling', () => {
+    it('should not return in-progress item when it has no open children', () => {
+      const parent = db.create({ title: 'Parent', priority: 'high', status: 'in-progress' });
+      db.create({ title: 'Done child', priority: 'high', status: 'completed', parentId: parent.id });
+
+      const result = db.findNextWorkItem();
+      expect(result.workItem).toBeNull();
+    });
+
+    it('should select direct child under in-progress item', () => {
+      const parent = db.create({ title: 'Parent', priority: 'high', status: 'in-progress' });
+      const child = db.create({ title: 'Child', priority: 'high', status: 'open', parentId: parent.id });
+
+      const result = db.findNextWorkItem();
+      expect(result.workItem!.id).toBe(child.id);
+    });
+
+    it('should skip in-progress item and select next open item when no open children', () => {
+      db.create({ title: 'In-progress parent', priority: 'high', status: 'in-progress' });
+      const openItem = db.create({ title: 'Other open task', priority: 'medium', status: 'open' });
+
+      const result = db.findNextWorkItem();
+      expect(result.workItem!.id).toBe(openItem.id);
+    });
+  });
+
+  // ─────────────────────────────────────────────────────────────────────
+  // Regression: Hierarchical sort (WL-0MLYIK4AA1WJPZNU)
+  // Parent-child relationships should influence selection via hierarchy
+  // descent from best root candidate.
+  // ─────────────────────────────────────────────────────────────────────
+  describe('hierarchical sort (WL-0MLYIK4AA1WJPZNU)', () => {
+    it('should descend into best child of selected root', () => {
+      const parent = db.create({ title: 'Parent', priority: 'high', status: 'open', sortIndex: 100 });
+      const bestChild = db.create({ title: 'Best child', priority: 'high', status: 'open', parentId: parent.id, sortIndex: 200 });
+      db.create({ title: 'Other child', priority: 'low', status: 'open', parentId: parent.id, sortIndex: 300 });
+
+      const result = db.findNextWorkItem();
+      expect(result.workItem!.id).toBe(bestChild.id);
+    });
+
+    it('should select among root-level candidates using sortIndex', () => {
+      db.create({ title: 'Root A', priority: 'medium', status: 'open', sortIndex: 300 });
+      const rootB = db.create({ title: 'Root B', priority: 'medium', status: 'open', sortIndex: 100 });
+      db.create({ title: 'Root C', priority: 'medium', status: 'open', sortIndex: 200 });
+
+      const result = db.findNextWorkItem();
+      expect(result.workItem!.id).toBe(rootB.id);
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Add a comprehensive regression test suite (48 tests) covering all 10+ prior bug-fix scenarios for the `wl next` algorithm, establishing a safety net before the algorithm rebuild (WL-0MM2FKKOW1H0C0G4).

## Changes

- Created `tests/next-regression.test.ts` with 48 regression tests covering:
  - Deleted items filtered (WL-0MLDIFLCR1REKNGA)
  - Orphan promotion under completed/deleted parents (WL-0MM1CD2IJ1R2ZI5J)
  - Childless epic eligibility (WL-0MM1CD3SP1CO6NK9)
  - Batch dedup / unique results (WL-0MLFU4PQA1EJ1OQK)
  - In-review exclusion (WL-0ML2TS8I409ALBU6)
  - Blocker-vs-priority ordering (WL-0MLYHCZCS1FY5I6H)
  - Blocked item filtering (WL-0MLZWO96O1RS086V)
  - Priority inheritance / scoring boost (WL-0MM0B4FNW0ZLOTV8)
  - Age-based tiebreaker timing (WL-0MM17NRAY0FJ1AK5)
  - Blocked/in-review flag behavior (WL-0MLC3SUXI0QI9I3L)
  - Formal-only blocking (WL-0MLPSNIEL161NV6C)
  - Fixture-based integration tests
  - In-progress handling
  - Hierarchical sort (WL-0MLYIK4AA1WJPZNU)

## Testing

- All 48 new regression tests pass
- Full test suite (87 files, 1043 tests) passes with no regressions

## Work Item

Part of epic WL-0MM2FKKOW1H0C0G4 (Rebuild wl next algorithm). This is child task #1 of 8.