### PR TITLE
WL-0MM346MLV0THH548: Extract handleCriticalEscalation() method

### DIFF
--- a/src/database.ts
+++ b/src/database.ts
@@ -814,6 +814,146 @@ export class WorklogDatabase {
   }
 
   /**
+   * Handle critical-path escalation (Stage 2 of the next-item algorithm).
+   *
+   * Critical items are always prioritized above non-critical items:
+   *   - Unblocked criticals are selected first by sortIndex (priority+age fallback).
+   *   - Blocked criticals surface their direct blocker (child or dependency edge)
+   *     with the highest effective priority.
+   *   - An unblocked critical always wins over a blocker of a non-critical item.
+   *
+   * Operates on the FULL item set so that critical items outside the
+   * assignee/search filter are still considered — only the final blocker
+   * selection is filtered by assignee/search.
+   *
+   * @returns NextWorkItemResult if critical escalation selects an item, null otherwise
+   */
+  private handleCriticalEscalation(
+    allItems: WorkItem[],
+    options: {
+      assignee?: string;
+      searchTerm?: string;
+      excluded?: Set<string>;
+      includeInReview?: boolean;
+      debugPrefix?: string;
+    } = {}
+  ): NextWorkItemResult | null {
+    const {
+      assignee,
+      searchTerm,
+      excluded,
+      includeInReview = false,
+      debugPrefix = '[critical]',
+    } = options;
+
+    // Find all critical items from the full set, excluding only
+    // deleted/completed/in-progress (these are never actionable).
+    // Also exclude blocked+in_review items unless includeInReview is set.
+    const criticalItems = allItems.filter(
+      item =>
+        item.priority === 'critical' &&
+        item.status !== 'deleted' &&
+        item.status !== 'completed' &&
+        item.status !== 'in-progress' &&
+        (includeInReview || !(item.stage === 'in_review' && item.status === 'blocked'))
+    );
+    this.debug(`${debugPrefix} critical items from full set=${criticalItems.length}`);
+
+    if (criticalItems.length === 0) {
+      return null;
+    }
+
+    // ── Unblocked criticals ──
+    // An item is "unblocked" if it is not blocked AND has no non-closed children
+    // (children act as implicit blockers).
+    const unblockedCriticals = criticalItems.filter(
+      item => item.status !== 'blocked' && this.getNonClosedChildren(item.id).length === 0
+    );
+    this.debug(`${debugPrefix} unblocked criticals=${unblockedCriticals.length}`);
+
+    if (unblockedCriticals.length > 0) {
+      // Apply assignee/search to unblocked criticals — only return items
+      // that match the caller's filters.
+      let selectable = this.applyFilters(unblockedCriticals, assignee, searchTerm);
+      if (excluded && excluded.size > 0) {
+        selectable = selectable.filter(item => !excluded.has(item.id));
+      }
+      this.debug(`${debugPrefix} unblocked criticals after filters=${selectable.length}`);
+
+      if (selectable.length > 0) {
+        const selected = this.selectBySortIndex(selectable);
+        this.debug(`${debugPrefix} selected unblocked critical=${selected?.id || ''} title="${selected?.title || ''}"`);
+        return {
+          workItem: selected,
+          reason: `Next unblocked critical item by sort_index${selected ? ` (priority ${selected.priority})` : ''}`
+        };
+      }
+    }
+
+    // ── Blocked criticals ──
+    // For each blocked critical, gather its direct blockers (children + dependency edges)
+    // from the full item store, then select the best blocker that passes filters.
+    const blockedCriticals = criticalItems.filter(
+      item => item.status === 'blocked'
+    );
+    this.debug(`${debugPrefix} blocked criticals=${blockedCriticals.length}`);
+
+    if (blockedCriticals.length > 0) {
+      const blockingPairs: { blocking: WorkItem; critical: WorkItem }[] = [];
+
+      for (const critical of blockedCriticals) {
+        // Child blockers (non-closed children implicitly block a parent)
+        const blockingChildren = this.getNonClosedChildren(critical.id);
+        for (const child of blockingChildren) {
+          if (excluded?.has(child.id)) continue;
+          blockingPairs.push({ blocking: child, critical });
+          this.debug(`${debugPrefix}   blocker: child ${child.id} ("${child.title}") blocks critical ${critical.id}`);
+        }
+
+        // Dependency-edge blockers
+        const dependencyBlockers = this.getActiveDependencyBlockers(critical.id);
+        for (const blocker of dependencyBlockers) {
+          if (excluded?.has(blocker.id)) continue;
+          blockingPairs.push({ blocking: blocker, critical });
+          this.debug(`${debugPrefix}   blocker: dep ${blocker.id} ("${blocker.title}") blocks critical ${critical.id}`);
+        }
+      }
+
+      // Apply assignee/search filters to the blockers only
+      const filteredBlockingPairs = blockingPairs.filter(pair =>
+        this.applyFilters([pair.blocking], assignee, searchTerm).length > 0
+      );
+      this.debug(`${debugPrefix} blocking candidates=${blockingPairs.length} after filters=${filteredBlockingPairs.length}`);
+
+      const selectedBlocking = this.selectHighestPriorityBlocking(filteredBlockingPairs);
+
+      if (selectedBlocking) {
+        this.debug(`${debugPrefix} selected blocker=${selectedBlocking.blocking.id} ("${selectedBlocking.blocking.title}") for critical ${selectedBlocking.critical.id}`);
+        return {
+          workItem: selectedBlocking.blocking,
+          reason: `Blocking issue for critical item ${selectedBlocking.critical.id} (${selectedBlocking.critical.title})`
+        };
+      }
+
+      // No actionable blocker found — return the blocked critical itself as a
+      // last resort so the user is aware of the stuck critical item.
+      let selectableBlocked = this.applyFilters(blockedCriticals, assignee, searchTerm);
+      if (excluded && excluded.size > 0) {
+        selectableBlocked = selectableBlocked.filter(item => !excluded.has(item.id));
+      }
+      const selectedBlockedCritical = this.selectBySortIndex(selectableBlocked.length > 0 ? selectableBlocked : blockedCriticals);
+      this.debug(`${debugPrefix} selected blocked critical (fallback)=${selectedBlockedCritical?.id || ''}`);
+      return {
+        workItem: selectedBlockedCritical,
+        reason: 'Blocked critical work item with no identifiable blocking issues'
+      };
+    }
+
+    // No critical items to escalate
+    return null;
+  }
+
+  /**
    * Compute a score for an item. Defaults: recencyPolicy='ignore'.
    * Higher score == more desirable.
    */
@@ -1061,66 +1201,18 @@ export class WorklogDatabase {
     });
 
     // ── Stage 2: Critical-path escalation ──
-    const criticalItems = criticalPool.filter(
-      item => item.priority === 'critical'
-    );
-    this.debug(`${debugPrefix} critical items=${criticalItems.length}`);
-    const unblockedCriticals = criticalItems.filter(
-      item => item.status !== 'blocked' && this.getNonClosedChildren(item.id).length === 0
-    );
-
-    this.debug(`${debugPrefix} unblocked criticals=${unblockedCriticals.length}`);
-
-    if (unblockedCriticals.length > 0) {
-      const selected = this.selectBySortIndex(unblockedCriticals);
-      this.debug(`${debugPrefix} selected critical=${selected?.id || ''}`);
-      return {
-        workItem: selected,
-        reason: `Next unblocked critical item by sort_index${selected ? ` (priority ${selected.priority})` : ''}`
-      };
-    }
-
-    const blockedCriticals = criticalItems.filter(
-      item => item.status === 'blocked'
-    );
-    this.debug(`${debugPrefix} blocked criticals=${blockedCriticals.length}`);
-    if (blockedCriticals.length > 0) {
-      const blockingPairs: { blocking: WorkItem; critical: WorkItem }[] = [];
-
-      for (const critical of blockedCriticals) {
-        const blockingChildren = this.getNonClosedChildren(critical.id);
-        for (const child of blockingChildren) {
-          if (excluded?.has(child.id)) continue;
-          blockingPairs.push({ blocking: child, critical });
-        }
-
-        const dependencyBlockers = this.getActiveDependencyBlockers(critical.id);
-        for (const blocker of dependencyBlockers) {
-          if (excluded?.has(blocker.id)) continue;
-          blockingPairs.push({ blocking: blocker, critical });
-        }
-      }
-
-      const filteredBlockingPairs = blockingPairs.filter(pair =>
-        this.applyFilters([pair.blocking], assignee, searchTerm).length > 0
-      );
-      const selectedBlocking = this.selectHighestPriorityBlocking(filteredBlockingPairs);
-
-      this.debug(`${debugPrefix} blocking candidates=${filteredBlockingPairs.length} selectedBlocking=${selectedBlocking?.blocking.id || ''}`);
-
-      if (selectedBlocking) {
-        return {
-          workItem: selectedBlocking.blocking,
-          reason: `Blocking issue for critical item ${selectedBlocking.critical.id} (${selectedBlocking.critical.title})`
-        };
-      }
-
-      const selectedBlockedCritical = this.selectBySortIndex(blockedCriticals);
-      this.debug(`${debugPrefix} selected blocked critical=${selectedBlockedCritical?.id || ''}`);
-      return {
-        workItem: selectedBlockedCritical,
-        reason: 'Blocked critical work item with no identifiable blocking issues'
-      };
+    // Delegated to handleCriticalEscalation() which operates on the full
+    // item set so that critical items outside the assignee/search filter
+    // can still surface their blockers.
+    const criticalResult = this.handleCriticalEscalation(items, {
+      assignee,
+      searchTerm,
+      excluded,
+      includeInReview,
+      debugPrefix: `${debugPrefix} [critical]`,
+    });
+    if (criticalResult) {
+      return criticalResult;
     }
 
     // ── Stage 3: Non-critical blocker surfacing ──

--- a/tests/next-regression.test.ts
+++ b/tests/next-regression.test.ts
@@ -719,4 +719,279 @@ describe('wl next regression tests (WL-0MM2FKKOW1H0C0G4)', () => {
       expect(result.workItem!.id).toBe(rootB.id);
     });
   });
+
+  // ─────────────────────────────────────────────────────────────────────
+  // Critical Escalation (WL-0MM346MLV0THH548)
+  // handleCriticalEscalation() operates on the full item set.
+  // Unblocked criticals win over all non-criticals; blocked criticals
+  // surface their direct blocker (child or dependency edge).
+  // ─────────────────────────────────────────────────────────────────────
+  describe('critical escalation (WL-0MM346MLV0THH548)', () => {
+    it('should surface blocker of critical item assigned to a different user', async () => {
+      // Critical item assigned to Bob is blocked by a task assigned to Alice.
+      // When Alice queries wl next --assignee alice, the blocker should surface
+      // because handleCriticalEscalation operates on the FULL item set.
+      const critical = db.create({
+        title: 'Critical Bob item',
+        priority: 'critical',
+        status: 'blocked',
+        assignee: 'bob',
+      });
+      const aliceBlocker = db.create({
+        title: 'Alice blocker',
+        priority: 'medium',
+        status: 'open',
+        assignee: 'alice',
+        parentId: critical.id,
+      });
+      await wait(10);
+      db.create({
+        title: 'Alice normal task',
+        priority: 'high',
+        status: 'open',
+        assignee: 'alice',
+      });
+
+      const result = db.findNextWorkItem('alice');
+      expect(result.workItem).not.toBeNull();
+      expect(result.workItem!.id).toBe(aliceBlocker.id);
+      expect(result.reason).toContain('critical');
+    });
+
+    it('should surface dep-edge blocker of critical item from full set', async () => {
+      // Critical item has a dependency-edge blocker. The blocker is not
+      // assigned to anyone, but should still be surfaced.
+      const critical = db.create({
+        title: 'Critical with dep',
+        priority: 'critical',
+        status: 'blocked',
+        assignee: 'bob',
+      });
+      const blocker = db.create({
+        title: 'Dependency blocker',
+        priority: 'medium',
+        status: 'open',
+      });
+      db.addDependencyEdge(critical.id, blocker.id);
+      await wait(10);
+      db.create({
+        title: 'Other task',
+        priority: 'high',
+        status: 'open',
+      });
+
+      const result = db.findNextWorkItem();
+      expect(result.workItem).not.toBeNull();
+      expect(result.workItem!.id).toBe(blocker.id);
+      expect(result.reason).toContain('critical');
+    });
+
+    it('should prefer unblocked critical over non-critical items regardless of sortIndex', async () => {
+      // Even if a non-critical has a better sortIndex, the unblocked critical wins.
+      db.create({
+        title: 'Non-critical first',
+        priority: 'high',
+        status: 'open',
+        sortIndex: 1,
+      });
+      await wait(10);
+      const critical = db.create({
+        title: 'Critical item',
+        priority: 'critical',
+        status: 'open',
+        sortIndex: 999,
+      });
+
+      const result = db.findNextWorkItem();
+      expect(result.workItem).not.toBeNull();
+      expect(result.workItem!.id).toBe(critical.id);
+      expect(result.reason).toContain('critical');
+    });
+
+    it('should select among multiple unblocked criticals by sortIndex', () => {
+      db.create({
+        title: 'Critical A',
+        priority: 'critical',
+        status: 'open',
+        sortIndex: 300,
+      });
+      const criticalB = db.create({
+        title: 'Critical B',
+        priority: 'critical',
+        status: 'open',
+        sortIndex: 100,
+      });
+      db.create({
+        title: 'Critical C',
+        priority: 'critical',
+        status: 'open',
+        sortIndex: 200,
+      });
+
+      const result = db.findNextWorkItem();
+      expect(result.workItem).not.toBeNull();
+      expect(result.workItem!.id).toBe(criticalB.id);
+    });
+
+    it('should fall back to priority+age when all criticals have same sortIndex', async () => {
+      const criticalOld = db.create({
+        title: 'Critical old',
+        priority: 'critical',
+        status: 'open',
+        sortIndex: 0,
+      });
+      await wait(10);
+      db.create({
+        title: 'Critical new',
+        priority: 'critical',
+        status: 'open',
+        sortIndex: 0,
+      });
+
+      const result = db.findNextWorkItem();
+      expect(result.workItem).not.toBeNull();
+      // Same priority, same sortIndex — oldest wins
+      expect(result.workItem!.id).toBe(criticalOld.id);
+    });
+
+    it('should return blocked critical as last resort when no blockers found', () => {
+      // A blocked critical with no children and no dep edges
+      const critical = db.create({
+        title: 'Stuck critical',
+        priority: 'critical',
+        status: 'blocked',
+      });
+
+      const result = db.findNextWorkItem();
+      expect(result.workItem).not.toBeNull();
+      expect(result.workItem!.id).toBe(critical.id);
+      expect(result.reason).toContain('no identifiable blocking issues');
+    });
+
+    it('should not surface blocked+in_review critical when includeInReview is false', () => {
+      db.create({
+        title: 'In review critical',
+        priority: 'critical',
+        status: 'blocked',
+        stage: 'in_review',
+      });
+      const openItem = db.create({
+        title: 'Open low',
+        priority: 'low',
+        status: 'open',
+      });
+
+      const result = db.findNextWorkItem();
+      expect(result.workItem).not.toBeNull();
+      expect(result.workItem!.id).toBe(openItem.id);
+    });
+
+    it('should surface blocked+in_review critical when includeInReview is true', () => {
+      const critical = db.create({
+        title: 'In review critical',
+        priority: 'critical',
+        status: 'blocked',
+        stage: 'in_review',
+      });
+      db.create({
+        title: 'Open low',
+        priority: 'low',
+        status: 'open',
+      });
+
+      const result = db.findNextWorkItem(undefined, undefined, true);
+      expect(result.workItem).not.toBeNull();
+      expect(result.workItem!.id).toBe(critical.id);
+    });
+
+    it('should surface blocker from outside search filter for critical item', async () => {
+      // Critical item mentions "infra" in its title but its blocker mentions "auth".
+      // When searching for "auth", the blocker should be surfaced because
+      // critical escalation finds the critical from the full set.
+      const critical = db.create({
+        title: 'Critical infra issue',
+        priority: 'critical',
+        status: 'blocked',
+      });
+      const blocker = db.create({
+        title: 'Auth service fix',
+        priority: 'medium',
+        status: 'open',
+        parentId: critical.id,
+      });
+      await wait(10);
+      db.create({
+        title: 'Auth docs update',
+        priority: 'low',
+        status: 'open',
+      });
+
+      const result = db.findNextWorkItem(undefined, 'auth');
+      expect(result.workItem).not.toBeNull();
+      expect(result.workItem!.id).toBe(blocker.id);
+      expect(result.reason).toContain('critical');
+    });
+
+    it('should handle critical with both child and dep-edge blockers', async () => {
+      // Critical item has both a child and a dep-edge blocker.
+      // Either blocker may be selected depending on hierarchy sort order;
+      // the important thing is that one of them is surfaced.
+      const critical = db.create({
+        title: 'Critical with both',
+        priority: 'critical',
+        status: 'blocked',
+      });
+      const childBlocker = db.create({
+        title: 'Child blocker',
+        priority: 'medium',
+        status: 'open',
+        parentId: critical.id,
+        sortIndex: 200,
+      });
+      const depBlocker = db.create({
+        title: 'Dep blocker',
+        priority: 'medium',
+        status: 'open',
+        sortIndex: 100,
+      });
+      db.addDependencyEdge(critical.id, depBlocker.id);
+
+      const result = db.findNextWorkItem();
+      expect(result.workItem).not.toBeNull();
+      // Either blocker is acceptable; both unblock the critical
+      const selectedId = result.workItem!.id;
+      expect([childBlocker.id, depBlocker.id]).toContain(selectedId);
+      expect(result.reason).toContain('critical');
+    });
+
+    it('should skip excluded blockers in batch mode', async () => {
+      const critical = db.create({
+        title: 'Critical parent',
+        priority: 'critical',
+        status: 'blocked',
+      });
+      const child1 = db.create({
+        title: 'First child',
+        priority: 'high',
+        status: 'open',
+        parentId: critical.id,
+        sortIndex: 100,
+      });
+      await wait(10);
+      const child2 = db.create({
+        title: 'Second child',
+        priority: 'high',
+        status: 'open',
+        parentId: critical.id,
+        sortIndex: 200,
+      });
+
+      const results = db.findNextWorkItems(2);
+      expect(results.length).toBe(2);
+      // First batch result should pick child1 (lower sortIndex)
+      expect(results[0].workItem!.id).toBe(child1.id);
+      // Second batch result should pick child2 (child1 is excluded)
+      expect(results[1].workItem!.id).toBe(child2.id);
+    });
+  });
 });


### PR DESCRIPTION
## Summary

Extracts the inline critical-path escalation logic (Stage 2 of the `wl next` algorithm) from `findNextWorkItemFromItems` into a dedicated `handleCriticalEscalation()` method.

## Key Changes

- **New `handleCriticalEscalation()` method** (`src/database.ts:825-950`) — fully documented private method that encapsulates all critical-path escalation logic
- **Operates on the full item set** — critical items are found from the complete set (excluding only deleted/completed/in-progress), so cross-assignee and cross-search blocker surfacing works correctly. Previously, critical items came from the pre-filtered `criticalPool` which had assignee/search filters already applied
- **Respects `includeInReview` flag** for blocked+in_review critical items
- **Detailed debug tracing** — logs each blocker candidate (child vs dep-edge) with item IDs and titles
- **11 new regression tests** (59 total, up from 48) covering:
  - Cross-assignee blocker surfacing
  - Dep-edge blockers from full set
  - Unblocked critical priority over non-criticals regardless of sortIndex
  - sortIndex selection among multiple criticals
  - Priority+age fallback when sortIndex values are equal
  - Blocked critical last resort (no identifiable blockers)
  - in_review flag behavior (include/exclude)
  - Search filter bypass for blocker surfacing
  - Mixed child + dep-edge blockers
  - Batch mode exclusion

## Test Results

- All 1092 tests pass across 90 test files
- Clean TypeScript build (no type errors)

## Work Item

Closes acceptance criteria for Critical Escalation (WL-0MM346MLV0THH548), child of Rebuild wl next algorithm (WL-0MM2FKKOW1H0C0G4).