### PR TITLE
Fix 5 flaky tests with same-millisecond timestamp collisions

### DIFF
--- a/tests/database.test.ts
+++ b/tests/database.test.ts
@@ -762,9 +762,12 @@ describe('WorklogDatabase', () => {
       expect(result.reason).toContain('Next open item by sort_index');
     });
 
-    it('should select highest priority child when multiple children exist', () => {
+    it('should select highest priority child when multiple children exist', async () => {
       const parent = db.create({ title: 'Parent', priority: 'high', status: 'in-progress' });
       const lowLeaf = db.create({ title: 'Low leaf', priority: 'low', status: 'open', parentId: parent.id });
+      // Small delay to ensure different timestamps for createdAt tiebreaking
+      const delay = () => new Promise(resolve => setTimeout(resolve, 10));
+      await delay();
       db.create({ title: 'High leaf', priority: 'high', status: 'open', parentId: parent.id });
       
       const result = db.findNextWorkItem();
@@ -955,7 +958,7 @@ describe('WorklogDatabase', () => {
       expect(result.reason).toContain('Blocking issue');
     });
 
-    it('Phase 4: sibling wins over child of lower-priority parent (Example 1)', () => {
+    it('Phase 4: sibling wins over child of lower-priority parent (Example 1)', async () => {
       // A (low, open), B (high, open, child of A), C (medium, open, sibling of A)
       // Grandparent is high priority.
       // With effective priority inheritance:
@@ -963,33 +966,42 @@ describe('WorklogDatabase', () => {
       //   C: own=medium, inherited=high (from grandparent) → effective=high
       // Both tie on effective priority, so createdAt picks A (older).
       // Then we descend into A's children and select B.
+      const delay = () => new Promise(resolve => setTimeout(resolve, 10));
       const grandparent = db.create({ title: 'Grandparent', priority: 'high', status: 'open' });
       const itemA = db.create({ title: 'Item A', priority: 'low', status: 'open', parentId: grandparent.id });
       const itemB = db.create({ title: 'Item B', priority: 'high', status: 'open', parentId: itemA.id });
+      // Small delay to ensure itemC has a later createdAt than itemA
+      await delay();
       db.create({ title: 'Item C', priority: 'medium', status: 'open', parentId: grandparent.id });
 
       const result = db.findNextWorkItem();
       expect(result.workItem?.id).toBe(itemB.id);
     });
 
-    it('Phase 4: child wins when parent priority >= sibling (Example 2)', () => {
+    it('Phase 4: child wins when parent priority >= sibling (Example 2)', async () => {
       // A (medium, open), B (high, open, child of A), C (medium, open, sibling of A)
       // Expected: B wins because A (medium) >= C (medium)
+      const delay = () => new Promise(resolve => setTimeout(resolve, 10));
       const grandparent = db.create({ title: 'Grandparent', priority: 'high', status: 'open' });
       const itemA = db.create({ title: 'Item A', priority: 'medium', status: 'open', parentId: grandparent.id });
       const itemB = db.create({ title: 'Item B', priority: 'high', status: 'open', parentId: itemA.id });
+      // Small delay to ensure itemC has a later createdAt than itemA
+      await delay();
       db.create({ title: 'Item C', priority: 'medium', status: 'open', parentId: grandparent.id });
 
       const result = db.findNextWorkItem();
       expect(result.workItem?.id).toBe(itemB.id);
     });
 
-    it('Phase 4: low-priority child wins when parent priority >= sibling (Example 3)', () => {
+    it('Phase 4: low-priority child wins when parent priority >= sibling (Example 3)', async () => {
       // A (medium, open), B (low, open, child of A), C (medium, open, sibling of A)
       // Expected: B wins because A (medium) >= C (medium), and B is A's child
+      const delay = () => new Promise(resolve => setTimeout(resolve, 10));
       const grandparent = db.create({ title: 'Grandparent', priority: 'high', status: 'open' });
       const itemA = db.create({ title: 'Item A', priority: 'medium', status: 'open', parentId: grandparent.id });
       const itemB = db.create({ title: 'Item B', priority: 'low', status: 'open', parentId: itemA.id });
+      // Small delay to ensure itemC has a later createdAt than itemA
+      await delay();
       db.create({ title: 'Item C', priority: 'medium', status: 'open', parentId: grandparent.id });
 
       const result = db.findNextWorkItem();
@@ -1006,9 +1018,12 @@ describe('WorklogDatabase', () => {
       expect(result.workItem?.id).toBe(highItem.id);
     });
 
-    it('Phase 4: top-level item with children descends to best child', () => {
+    it('Phase 4: top-level item with children descends to best child', async () => {
       const parent = db.create({ title: 'Parent', priority: 'high', status: 'open' });
       const bestChild = db.create({ title: 'Best child', priority: 'high', status: 'open', parentId: parent.id });
+      // Small delay to ensure bestChild has an earlier createdAt than otherChild
+      const delay = () => new Promise(resolve => setTimeout(resolve, 10));
+      await delay();
       db.create({ title: 'Other child', priority: 'low', status: 'open', parentId: parent.id });
 
       const result = db.findNextWorkItem();


### PR DESCRIPTION
## Summary

Fix 5 flaky `findNextWorkItem` tests in `tests/database.test.ts` that intermittently fail due to same-millisecond `createdAt` timestamp collisions. When two work items are created synchronously and share the same millisecond timestamp, the tiebreaker falls through to non-deterministic ID comparison (IDs contain a random component), causing tests to pass or fail unpredictably.

## Work Items

- [test-failure] should select highest priority child when multiple children exist — failing test (WL-0MM615M9A0RL3U99) — parent
- Fix flaky priority-child test (WL-0MM65VDY91MF1BF7) — child task 1
- Fix remaining timestamp-dependent tests (WL-0MM65VL2Z1942995) — child task 2

## Changes

Added async delays (10ms) between synchronous `db.create()` calls that rely on `createdAt` ordering for tiebreaking. This follows the established pattern from commit `285cadb` (PR #751).

### Tests fixed:
1. **`should select highest priority child when multiple children exist`** (line 765) — The known CI-failing test. Both children inherit high effective priority from their in-progress parent; `createdAt` tiebreaker must pick the older child.
2. **`Phase 4: sibling wins over child of lower-priority parent (Example 1)`** (line 961) — itemA and itemC tie on effective priority; `createdAt` must pick itemA (older).
3. **`Phase 4: child wins when parent priority >= sibling (Example 2)`** (line 978) — Same pattern as above.
4. **`Phase 4: low-priority child wins when parent priority >= sibling (Example 3)`** (line 990) — Same pattern as above.
5. **`Phase 4: top-level item with children descends to best child`** (line 1012) — bestChild and otherChild have equal effective priority; `createdAt` must pick bestChild (older).

### What was NOT changed:
- No production code changes
- No test semantics changed (what each test validates is preserved)
- `tests/sort-operations.test.ts` was audited and does not need changes (uses explicit `sortIndex` values)

## How to test

```bash
# Run the specific tests
npx vitest run tests/database.test.ts

# Run just the affected tests
npx vitest run tests/database.test.ts -t "should select highest priority child"
npx vitest run tests/database.test.ts -t "Phase 4:"
```

All 114 database tests should pass deterministically.

## Review focus

- Verify that the delay placement is correct (between the creates that the ordering depends on)
- Confirm that no test assertions or expected values were altered
- Confirm consistency with the established pattern at lines 619-625 of the same file