### PR TITLE
WL-0MM79H1JR0ZFY0W2: Add progress feedback for comment fetch phase during gh import

### DIFF
--- a/src/commands/github.ts
+++ b/src/commands/github.ts
@@ -65,7 +65,11 @@ export default function register(ctx: PluginContext): void {
             ? 'Import'
             : progress.phase === 'hierarchy'
               ? 'Hierarchy'
-              : 'Close check';
+              : progress.phase === 'comments'
+                ? 'Comments'
+                : progress.phase === 'saving'
+                  ? 'Saving'
+                  : 'Close check';
         const message = `${label}: ${progress.current}/${progress.total}`;
         if (message === lastProgress) {
           return;
@@ -293,7 +297,11 @@ export default function register(ctx: PluginContext): void {
             ? 'Import'
             : progress.phase === 'hierarchy'
               ? 'Hierarchy'
-              : 'Close check';
+              : progress.phase === 'comments'
+                ? 'Comments'
+                : progress.phase === 'saving'
+                  ? 'Saving'
+                  : 'Close check';
         const message = `${label}: ${progress.current}/${progress.total}`;
         if (message === lastProgress) {
           return;
@@ -326,11 +334,13 @@ export default function register(ctx: PluginContext): void {
         });
 
         if (mergedItems.length > 0) {
+          renderProgress({ phase: 'saving', current: 1, total: 2 });
           db.import(mergedItems);
         }
 
         // Persist imported GitHub comments
         if (importedComments.length > 0) {
+          renderProgress({ phase: 'saving', current: 2, total: 2 });
           const existingComments = db.getAllComments();
           // Merge: keep existing, add new ones that don't clash by githubCommentId
           const existingGhIds = new Set(

--- a/src/github-sync.ts
+++ b/src/github-sync.ts
@@ -77,7 +77,7 @@ export interface GithubSyncTiming {
 }
 
 export interface GithubProgress {
-  phase: 'push' | 'import' | 'close-check' | 'hierarchy';
+  phase: 'push' | 'import' | 'close-check' | 'hierarchy' | 'comments' | 'saving';
   current: number;
   total: number;
 }
@@ -1156,7 +1156,12 @@ export async function importIssuesToWorkItems(
   }
 
   // Fetch comments for every issue that was processed during this import
-  for (const issueNumber of seenIssueNumbers) {
+  const seenIssueArray = [...seenIssueNumbers];
+  const seenIssueTotal = seenIssueArray.length;
+  let seenIssueIndex = 0;
+  for (const issueNumber of seenIssueArray) {
+    seenIssueIndex++;
+    onProgress?.({ phase: 'comments', current: seenIssueIndex, total: seenIssueTotal });
     const workItemId = itemIdByIssueNumber.get(issueNumber);
     if (!workItemId) continue;
 


### PR DESCRIPTION
## Summary

- Adds `comments` and `saving` phases to the `GithubProgress` type so the CLI can report progress during the previously-silent comment-fetch and database-save phases of `wl gh import`
- Adds per-issue `onProgress` callbacks in the comment-fetch loop in `importIssuesToWorkItems()`, so the user sees `Comments: 1/381`, `Comments: 2/381`, etc.
- Adds `Saving: 1/2` and `Saving: 2/2` progress output before the `db.import()` and `db.importComments()` calls

## Problem

After `wl gh import` displays `Import: 381/381`, the command goes silent for a long time (minutes for large repos) while it sequentially fetches comments for every issue and then writes to the database. This makes the command appear hung.

## Changes

- **`src/github-sync.ts`**: Added `'comments' | 'saving'` to `GithubProgress.phase` union type. Added `onProgress` call with `phase: 'comments'` inside the comment-fetch `for...of` loop, reporting `current/total` progress.
- **`src/commands/github.ts`**: Added `'Comments'` and `'Saving'` labels to both `renderProgress` functions (push and import commands). Added `renderProgress({ phase: 'saving', ... })` calls before `db.import()` and `db.importComments()`.

## Testing

All 1128 existing tests pass. The change is purely additive (progress reporting callbacks) with no behavioral changes to import logic.

## Work Item

WL-0MM79H1JR0ZFY0W2