### PR TITLE
WL-0MM4OA55D1741ETF: Add missing tests for --no-re-sort and --recency-policy

### DIFF
--- a/tests/cli/issue-status.test.ts
+++ b/tests/cli/issue-status.test.ts
@@ -347,6 +347,25 @@ describe('CLI Issue Status Tests', () => {
       expect(result.results).toHaveLength(1);
       expect(result.results[0].workItem).toBeTruthy();
     });
+
+    it('should preserve stale sortIndex order with --no-re-sort flag', async () => {
+      // Create low-priority item first (gets sortIndex 100 via createWithNextSortIndex)
+      await execAsync(`tsx ${cliPath} create -t "Low priority first" -s open -p low`);
+      // Create high-priority item second (gets sortIndex 200 via createWithNextSortIndex)
+      await execAsync(`tsx ${cliPath} create -t "High priority second" -s open -p high`);
+
+      // With --no-re-sort FIRST: the original creation order (sortIndex) is preserved,
+      // so the low-priority item with sortIndex=100 should be selected over
+      // the high-priority item with sortIndex=200
+      const { stdout: withoutReSort } = await execAsync(`tsx ${cliPath} --json next --no-re-sort`);
+      const resultWithoutReSort = JSON.parse(withoutReSort);
+      expect(resultWithoutReSort.workItem.title).toBe('Low priority first');
+
+      // With default behavior (auto re-sort), high-priority item wins
+      const { stdout: withReSort } = await execAsync(`tsx ${cliPath} --json next`);
+      const resultWithReSort = JSON.parse(withReSort);
+      expect(resultWithReSort.workItem.title).toBe('High priority second');
+    });
   });
 
   describe('in-progress command', () => {

--- a/tests/database.test.ts
+++ b/tests/database.test.ts
@@ -1843,5 +1843,54 @@ describe('WorklogDatabase', () => {
 
       expect(result.workItem?.id).toBe(high.id);
     });
+
+    it('should preserve stale sortIndex order when reSort is NOT called (--no-re-sort behavior)', () => {
+      // Create items where sortIndex contradicts priority:
+      // Medium priority has low sortIndex (top position), high priority has high sortIndex (buried)
+      const medium = db.create({ title: 'Medium task', priority: 'medium', sortIndex: 100 });
+      db.create({ title: 'High priority task', priority: 'high', sortIndex: 5000 });
+
+      // Without calling reSort(), findNextWorkItem should use the stale sortIndex order.
+      // The medium-priority item has sortIndex=100 which is lower than 5000,
+      // so it should be selected first (sortIndex ascending = higher priority position).
+      const result = db.findNextWorkItem();
+
+      expect(result.workItem?.id).toBe(medium.id);
+    });
+
+    it('should change ordering based on recency policy (prefer vs avoid)', () => {
+      // Create two items with the same priority so recency is the tie-breaker
+      const itemA = db.create({ title: 'Task A - recently updated', priority: 'medium', sortIndex: 200 });
+      const itemB = db.create({ title: 'Task B - old update', priority: 'medium', sortIndex: 100 });
+
+      const store = (db as any).store;
+      const now = new Date();
+      const fiveDaysAgo = new Date(now.getTime() - 5 * 24 * 60 * 60 * 1000);
+
+      // Manipulate updatedAt directly via the store:
+      // Task A: updated just now (very recent — within both 48h prefer and 72h avoid windows)
+      // Task B: updated 5 days ago (stale — beyond both windows, so no recency effect)
+      store.saveWorkItem({ ...db.get(itemA.id)!, updatedAt: now.toISOString() });
+      store.saveWorkItem({ ...db.get(itemB.id)!, updatedAt: fiveDaysAgo.toISOString() });
+
+      // With 'prefer' policy: recently-updated Task A gets a recency BOOST,
+      // so it should have a better (lower) sortIndex after re-sort
+      db.reSort('prefer');
+      const afterPreferA = db.get(itemA.id)!;
+      const afterPreferB = db.get(itemB.id)!;
+      expect(afterPreferA.sortIndex).toBeLessThan(afterPreferB.sortIndex);
+
+      // Re-apply updatedAt manipulation because reSort() overwrites updatedAt
+      // for any item whose sortIndex changed
+      store.saveWorkItem({ ...db.get(itemA.id)!, updatedAt: now.toISOString() });
+      store.saveWorkItem({ ...db.get(itemB.id)!, updatedAt: fiveDaysAgo.toISOString() });
+
+      // With 'avoid' policy: recently-updated Task A gets a recency PENALTY,
+      // so it should have a worse (higher) sortIndex after re-sort
+      db.reSort('avoid');
+      const afterAvoidA = db.get(itemA.id)!;
+      const afterAvoidB = db.get(itemB.id)!;
+      expect(afterAvoidA.sortIndex).toBeGreaterThan(afterAvoidB.sortIndex);
+    });
   });
 });


### PR DESCRIPTION
## Summary

- Adds 3 missing tests to fully satisfy acceptance criteria AC#2 and AC#6 for the auto re-sort feature (WL-0MM4OA55D1741ETF)
- The core implementation was already merged via PR #774; this PR addresses the 2 partial acceptance criteria identified during audit due to missing test coverage

## Tests Added

### Unit tests (`tests/database.test.ts`)

1. **`--no-re-sort` preserves stale sortIndex order**: Creates items where high-priority has a high sortIndex (buried) and medium-priority has a low sortIndex. Without calling `reSort()`, verifies `findNextWorkItem()` selects the medium-priority item (stale sortIndex order preserved).

2. **`--recency-policy` affects actual ordering**: Creates two same-priority items, manipulates `updatedAt` timestamps directly via the store (one recent, one 5 days old). Verifies that `reSort('prefer')` gives the recently-updated item a better sortIndex, while `reSort('avoid')` gives it a worse sortIndex.

### CLI integration test (`tests/cli/issue-status.test.ts`)

3. **`--no-re-sort` flag via CLI**: Creates items via CLI where creation order contradicts priority order. Verifies `wl next --no-re-sort` preserves creation order (low-priority first), while `wl next` (default, with auto re-sort) selects the high-priority item.

## Acceptance Criteria Coverage

| AC | Description | Status |
|----|-------------|--------|
| AC#2 | `--no-re-sort` flag skips re-sort, preserving existing sortIndex order | Now fully covered (unit + CLI tests) |
| AC#6 | New tests cover: auto-re-sort changes selection, --no-re-sort preserves order, --recency-policy affects ordering | Now fully covered (all 3 sub-criteria have tests) |

All 1148 tests pass with no regressions.