### PR TITLE
WL-0MM8V5SF11MGNQNM: Audit db.import() call sites and add safety docs

### DIFF
--- a/src/api.ts
+++ b/src/api.ts
@@ -409,6 +409,9 @@ export function createAPI(db: WorklogDatabase) {
       db.setPrefix(defaultPrefix);
       const filepath = req.body.filepath || getDefaultDataPath();
       const { items, comments, dependencyEdges } = importFromJsonl(filepath);
+      // SAFETY: db.import() is destructive (clears all items before inserting).
+      // This is intentional here — the API import endpoint replaces the entire
+      // database with the contents of the JSONL file.
       db.import(items, dependencyEdges);
       db.importComments(comments);
       res.json({ message: 'Import successful', count: items.length, commentCount: comments.length });

--- a/src/commands/import.ts
+++ b/src/commands/import.ts
@@ -22,6 +22,9 @@ export default function register(ctx: PluginContext): void {
       withFileLock(lockPath, () => {
         const db = utils.getDatabase(options.prefix);
         const { items, comments, dependencyEdges } = importFromJsonl(filePath);
+        // SAFETY: db.import() is destructive (clears all items before inserting).
+        // This is intentional here — the import command replaces the entire
+        // database with the contents of the JSONL file.
         db.import(items, dependencyEdges);
         db.importComments(comments);
         

--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -857,6 +857,9 @@ async function performInitSync(dataPath: string, prefix?: string, isJsonMode: bo
   if (autoSyncEnabled) {
     db.setAutoSync(false);
   }
+  // SAFETY: db.import() is destructive (clears all items before inserting).
+  // This is safe here because itemMergeResult.merged is the complete merged
+  // set of local + remote items — no data is lost.
   db.import(itemMergeResult.merged, edgeMergeResult.merged);
   db.importComments(commentMergeResult.merged);
   if (autoSyncEnabled) {

--- a/src/commands/sync.ts
+++ b/src/commands/sync.ts
@@ -178,6 +178,9 @@ async function performSync(
   if (autoSyncEnabled) {
     db.setAutoSync(false);
   }
+  // SAFETY: db.import() is destructive (clears all items before inserting).
+  // This is safe here because itemMergeResult.merged is the complete merged
+  // set of local + remote items — no data is lost.
   db.import(itemMergeResult.merged, edgeMergeResult.merged);
   db.importComments(commentMergeResult.merged);
   if (autoSyncEnabled) {

--- a/src/database.ts
+++ b/src/database.ts
@@ -1666,7 +1666,21 @@ export class WorklogDatabase {
   }
 
   /**
-   * Import work items (replaces existing data)
+   * Import work items by **replacing** all existing data.
+   *
+   * **WARNING — DESTRUCTIVE**: This method calls `clearWorkItems()` (DELETE
+   * FROM workitems) before re-inserting the provided items. If `dependencyEdges`
+   * is supplied it also calls `clearDependencyEdges()` first. Any items or
+   * edges NOT included in the arguments will be permanently deleted.
+   *
+   * Only call this method with a **complete** item set (e.g. the result of
+   * merging local + remote data). For partial / incremental updates — such as
+   * syncing a subset of items back from GitHub — use {@link upsertItems}
+   * instead, which preserves items not in the provided array.
+   *
+   * @param items - The full set of work items to store.
+   * @param dependencyEdges - Optional full set of dependency edges. When
+   *   provided, existing edges are cleared and replaced with these.
    */
   import(items: WorkItem[], dependencyEdges?: DependencyEdge[]): void {
     this.store.clearWorkItems();

--- a/src/index.ts
+++ b/src/index.ts
@@ -55,6 +55,9 @@ async function performServerSync(): Promise<void> {
     if (originalAutoSync) {
       db.setAutoSync(false);
     }
+    // SAFETY: db.import() is destructive (clears all items before inserting).
+    // This is safe here because itemMergeResult.merged is the complete merged
+    // set of local + remote items — no data is lost.
     db.import(itemMergeResult.merged, edgeMergeResult.merged);
     db.importComments(commentMergeResult.merged);
     if (originalAutoSync) {


### PR DESCRIPTION
## Summary

- Adds detailed JSDoc to `db.import()` in `src/database.ts` warning it is destructive (clears all items before inserting) and recommending `upsertItems()` for partial updates.
- Adds inline `// SAFETY:` comments at all 5 remaining `db.import()` call sites documenting why each usage is safe.

## Audit results

All 5 remaining `db.import()` call sites pass complete item sets — no unsafe callers found:

| File | Line | Input | Verdict |
|---|---|---|---|
| `src/commands/sync.ts` | 181 | Full merged set (local + remote) | Safe |
| `src/commands/import.ts` | 25 | Full JSONL file contents (intentional replace) | Safe |
| `src/commands/init.ts` | 860 | Full merged set (local + remote) | Safe |
| `src/api.ts` | 412 | Full JSONL file contents (intentional replace) | Safe |
| `src/index.ts` | 58 | Full merged set (local + remote) | Safe |

The 4 previously-unsafe call sites in `src/commands/github.ts` were already fixed in PR #789 (replaced with `upsertItems()`).

## Context

Final task (Feature 4 of 4) for critical data-loss bug WL-0MM8RQOC902W3LM5:
1. WL-0MM8V4UPC02YMFXK - Add `db.upsertItems()` API (PR #788, merged)
2. WL-0MM8V55PV1Q32K7D - Replace `db.import()` with `db.upsertItems()` in GitHub flows (PR #789, merged)
3. WL-0MM8V5GTH06V9Z0P - Update mock-based tests to expose destructive behavior (PR #790, merged)
4. **WL-0MM8V5SF11MGNQNM - Audit `db.import()` call sites and add safety docs (this PR)**

## Test results

- Full test suite: 95 files, 1214 tests pass, 0 failures
- Changes are comment/doc-only, no behavioral changes